### PR TITLE
switch dependabot to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,11 @@ updates:
     directory: /
     open-pull-requests-limit: 10
     schedule:
-      interval: monthly
+      interval: daily
     labels: [] # Disable default labels
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: daily
     labels: [] # Disable default labels


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description
Make dependabot run more frequently. There's currently a backlog of security issues it could possibly address for us: https://github.com/foxglove/ros-typescript/security

