### PR TITLE
Dependabot: Ignore minor and patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    # Bump the constraint only if the original constraint is not compatible (i.e. new major version)
-    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--
     versioning-strategy: increase-if-necessary
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Ignore minor and patch releases in lockfiles.

`versioning-strategy: increase-if-necessary` introduced in https://github.com/foxglove/ros-typescript/pull/76 seems to successfully avoid unnecessary version bumps, but dependabot is still making lockfile update PRs (e.g. https://github.com/foxglove/ros-typescript/pull/79). 

This PR should prevent unnecessary lockfile updates too.