### PR TITLE
Add script to incorporate additional message definitions from additional ros sources.

### DIFF
--- a/packages/rosmsg-msgs-common/README.md
+++ b/packages/rosmsg-msgs-common/README.md
@@ -8,6 +8,34 @@ This library exports a map of ROS 1 and ROS 2 datatype string keys to [@foxglove
 
 @foxglove/rosmsg-msgs-common is licensed under the [MIT License](https://opensource.org/licenses/MIT).
 
+## Updating message definitions from URLs
+
+Use the workspace script to fetch additional `.msg` files and inline their dependencies across all `msgdefs/ros2*` directories.
+
+1. Add one or more raw `.msg` URLs to `packages/rosmsg-msgs-common/scripts/extra-message-def-urls.txt`.
+   - One URL per line; lines starting with `#` are comments.
+   - URLs must contain `/<package>/msg/<MessageName>.msg` (for example: `/grid_map_msgs/msg/GridMap.msg`).
+2. Run the update script:
+   - From the repo root:
+     ```bash
+     yarn workspace @foxglove/rosmsg-msgs-common update:msgdefs:urls
+     ```
+   - Or from the package directory `packages/rosmsg-msgs-common`:
+     ```bash
+     yarn update:msgdefs:urls
+     ```
+3. The script will:
+   - Download each `.msg` file listed.
+   - Write it into the matching location under each `msgdefs/ros2*` directory.
+   - Invoke `scripts/gendeps.ts` to inline transitive dependencies (includes/constants) so the files are self-contained.
+   - Print which files were updated.
+4. Review the changes under `packages/rosmsg-msgs-common/msgdefs/` and commit them.
+
+Notes:
+
+- URLs that do not match the `/<package>/msg/*.msg` structure are skipped.
+- If dependency expansion fails for a file, the original content (if any) is restored and an error is printed.
+
 ## Releasing
 
 1. Run `yarn version --[major|minor|patch]` to bump version

--- a/packages/rosmsg-msgs-common/msgdefs/ros2galactic/grid_map_msgs/msg/GridMap.msg
+++ b/packages/rosmsg-msgs-common/msgdefs/ros2galactic/grid_map_msgs/msg/GridMap.msg
@@ -1,0 +1,264 @@
+# Grid map header
+GridMapInfo info
+
+# Grid map layer names.
+string[] layers
+
+# Grid map basic layer names (optional). The basic layers
+# determine which layers from `layers` need to be valid
+# in order for a cell of the grid map to be valid.
+string[] basic_layers
+
+# Grid map data.
+std_msgs/Float32MultiArray[] data
+
+# Row start index (default 0).
+uint16 outer_start_index
+
+# Column start index (default 0).
+uint16 inner_start_index
+
+================================================================================
+MSG: grid_map_msgs/GridMapInfo
+# Header (time and frame)
+std_msgs/Header header
+
+# Resolution of the grid [m/cell].
+float64 resolution
+
+# Length in x-direction [m].
+float64 length_x
+
+# Length in y-direction [m].
+float64 length_y
+
+# Pose of the grid map center in the frame defined in `header` [m].
+geometry_msgs/Pose pose
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+
+================================================================================
+MSG: std_msgs/Float32MultiArray
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# Please look at the MultiArrayLayout message definition for
+# documentation on all multiarrays.
+
+MultiArrayLayout  layout        # specification of data layout
+float32[]         data          # array of data
+
+================================================================================
+MSG: std_msgs/MultiArrayLayout
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# The multiarray declares a generic multi-dimensional array of a
+# particular data type.  Dimensions are ordered from outer most
+# to inner most.
+#
+# Accessors should ALWAYS be written in terms of dimension stride
+# and specified outer-most dimension first.
+#
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]
+#
+# A standard, 3-channel 640x480 image with interleaved color channels
+# would be specified as:
+#
+# dim[0].label  = "height"
+# dim[0].size   = 480
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)
+# dim[1].label  = "width"
+# dim[1].size   = 640
+# dim[1].stride = 3*640 = 1920
+# dim[2].label  = "channel"
+# dim[2].size   = 3
+# dim[2].stride = 3
+#
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.
+
+MultiArrayDimension[] dim # Array of dimension properties
+uint32 data_offset        # padding bytes at front of data
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: std_msgs/MultiArrayLayout
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# The multiarray declares a generic multi-dimensional array of a
+# particular data type.  Dimensions are ordered from outer most
+# to inner most.
+#
+# Accessors should ALWAYS be written in terms of dimension stride
+# and specified outer-most dimension first.
+#
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]
+#
+# A standard, 3-channel 640x480 image with interleaved color channels
+# would be specified as:
+#
+# dim[0].label  = "height"
+# dim[0].size   = 480
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)
+# dim[1].label  = "width"
+# dim[1].size   = 640
+# dim[1].stride = 3*640 = 1920
+# dim[2].label  = "channel"
+# dim[2].size   = 3
+# dim[2].stride = 3
+#
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.
+
+MultiArrayDimension[] dim # Array of dimension properties
+uint32 data_offset        # padding bytes at front of data
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+

--- a/packages/rosmsg-msgs-common/msgdefs/ros2galactic/grid_map_msgs/msg/GridMapInfo.msg
+++ b/packages/rosmsg-msgs-common/msgdefs/ros2galactic/grid_map_msgs/msg/GridMapInfo.msg
@@ -1,0 +1,69 @@
+# Header (time and frame)
+std_msgs/Header header
+
+# Resolution of the grid [m/cell].
+float64 resolution
+
+# Length in x-direction [m].
+float64 length_x
+
+# Length in y-direction [m].
+float64 length_y
+
+# Pose of the grid map center in the frame defined in `header` [m].
+geometry_msgs/Pose pose
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+

--- a/packages/rosmsg-msgs-common/msgdefs/ros2humble/grid_map_msgs/msg/GridMap.msg
+++ b/packages/rosmsg-msgs-common/msgdefs/ros2humble/grid_map_msgs/msg/GridMap.msg
@@ -1,0 +1,264 @@
+# Grid map header
+GridMapInfo info
+
+# Grid map layer names.
+string[] layers
+
+# Grid map basic layer names (optional). The basic layers
+# determine which layers from `layers` need to be valid
+# in order for a cell of the grid map to be valid.
+string[] basic_layers
+
+# Grid map data.
+std_msgs/Float32MultiArray[] data
+
+# Row start index (default 0).
+uint16 outer_start_index
+
+# Column start index (default 0).
+uint16 inner_start_index
+
+================================================================================
+MSG: grid_map_msgs/GridMapInfo
+# Header (time and frame)
+std_msgs/Header header
+
+# Resolution of the grid [m/cell].
+float64 resolution
+
+# Length in x-direction [m].
+float64 length_x
+
+# Length in y-direction [m].
+float64 length_y
+
+# Pose of the grid map center in the frame defined in `header` [m].
+geometry_msgs/Pose pose
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+
+================================================================================
+MSG: std_msgs/Float32MultiArray
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# Please look at the MultiArrayLayout message definition for
+# documentation on all multiarrays.
+
+MultiArrayLayout  layout        # specification of data layout
+float32[]         data          # array of data
+
+================================================================================
+MSG: std_msgs/MultiArrayLayout
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# The multiarray declares a generic multi-dimensional array of a
+# particular data type.  Dimensions are ordered from outer most
+# to inner most.
+#
+# Accessors should ALWAYS be written in terms of dimension stride
+# and specified outer-most dimension first.
+#
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]
+#
+# A standard, 3-channel 640x480 image with interleaved color channels
+# would be specified as:
+#
+# dim[0].label  = "height"
+# dim[0].size   = 480
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)
+# dim[1].label  = "width"
+# dim[1].size   = 640
+# dim[1].stride = 3*640 = 1920
+# dim[2].label  = "channel"
+# dim[2].size   = 3
+# dim[2].stride = 3
+#
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.
+
+MultiArrayDimension[] dim # Array of dimension properties
+uint32 data_offset        # padding bytes at front of data
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: std_msgs/MultiArrayLayout
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# The multiarray declares a generic multi-dimensional array of a
+# particular data type.  Dimensions are ordered from outer most
+# to inner most.
+#
+# Accessors should ALWAYS be written in terms of dimension stride
+# and specified outer-most dimension first.
+#
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]
+#
+# A standard, 3-channel 640x480 image with interleaved color channels
+# would be specified as:
+#
+# dim[0].label  = "height"
+# dim[0].size   = 480
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)
+# dim[1].label  = "width"
+# dim[1].size   = 640
+# dim[1].stride = 3*640 = 1920
+# dim[2].label  = "channel"
+# dim[2].size   = 3
+# dim[2].stride = 3
+#
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.
+
+MultiArrayDimension[] dim # Array of dimension properties
+uint32 data_offset        # padding bytes at front of data
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+

--- a/packages/rosmsg-msgs-common/msgdefs/ros2humble/grid_map_msgs/msg/GridMapInfo.msg
+++ b/packages/rosmsg-msgs-common/msgdefs/ros2humble/grid_map_msgs/msg/GridMapInfo.msg
@@ -1,0 +1,69 @@
+# Header (time and frame)
+std_msgs/Header header
+
+# Resolution of the grid [m/cell].
+float64 resolution
+
+# Length in x-direction [m].
+float64 length_x
+
+# Length in y-direction [m].
+float64 length_y
+
+# Pose of the grid map center in the frame defined in `header` [m].
+geometry_msgs/Pose pose
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+

--- a/packages/rosmsg-msgs-common/msgdefs/ros2iron/grid_map_msgs/msg/GridMap.msg
+++ b/packages/rosmsg-msgs-common/msgdefs/ros2iron/grid_map_msgs/msg/GridMap.msg
@@ -1,0 +1,264 @@
+# Grid map header
+GridMapInfo info
+
+# Grid map layer names.
+string[] layers
+
+# Grid map basic layer names (optional). The basic layers
+# determine which layers from `layers` need to be valid
+# in order for a cell of the grid map to be valid.
+string[] basic_layers
+
+# Grid map data.
+std_msgs/Float32MultiArray[] data
+
+# Row start index (default 0).
+uint16 outer_start_index
+
+# Column start index (default 0).
+uint16 inner_start_index
+
+================================================================================
+MSG: grid_map_msgs/GridMapInfo
+# Header (time and frame)
+std_msgs/Header header
+
+# Resolution of the grid [m/cell].
+float64 resolution
+
+# Length in x-direction [m].
+float64 length_x
+
+# Length in y-direction [m].
+float64 length_y
+
+# Pose of the grid map center in the frame defined in `header` [m].
+geometry_msgs/Pose pose
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+
+================================================================================
+MSG: std_msgs/Float32MultiArray
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# Please look at the MultiArrayLayout message definition for
+# documentation on all multiarrays.
+
+MultiArrayLayout  layout        # specification of data layout
+float32[]         data          # array of data
+
+================================================================================
+MSG: std_msgs/MultiArrayLayout
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# The multiarray declares a generic multi-dimensional array of a
+# particular data type.  Dimensions are ordered from outer most
+# to inner most.
+#
+# Accessors should ALWAYS be written in terms of dimension stride
+# and specified outer-most dimension first.
+#
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]
+#
+# A standard, 3-channel 640x480 image with interleaved color channels
+# would be specified as:
+#
+# dim[0].label  = "height"
+# dim[0].size   = 480
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)
+# dim[1].label  = "width"
+# dim[1].size   = 640
+# dim[1].stride = 3*640 = 1920
+# dim[2].label  = "channel"
+# dim[2].size   = 3
+# dim[2].stride = 3
+#
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.
+
+MultiArrayDimension[] dim # Array of dimension properties
+uint32 data_offset        # padding bytes at front of data
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: std_msgs/MultiArrayLayout
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# The multiarray declares a generic multi-dimensional array of a
+# particular data type.  Dimensions are ordered from outer most
+# to inner most.
+#
+# Accessors should ALWAYS be written in terms of dimension stride
+# and specified outer-most dimension first.
+#
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]
+#
+# A standard, 3-channel 640x480 image with interleaved color channels
+# would be specified as:
+#
+# dim[0].label  = "height"
+# dim[0].size   = 480
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)
+# dim[1].label  = "width"
+# dim[1].size   = 640
+# dim[1].stride = 3*640 = 1920
+# dim[2].label  = "channel"
+# dim[2].size   = 3
+# dim[2].stride = 3
+#
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.
+
+MultiArrayDimension[] dim # Array of dimension properties
+uint32 data_offset        # padding bytes at front of data
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+

--- a/packages/rosmsg-msgs-common/msgdefs/ros2iron/grid_map_msgs/msg/GridMapInfo.msg
+++ b/packages/rosmsg-msgs-common/msgdefs/ros2iron/grid_map_msgs/msg/GridMapInfo.msg
@@ -1,0 +1,69 @@
+# Header (time and frame)
+std_msgs/Header header
+
+# Resolution of the grid [m/cell].
+float64 resolution
+
+# Length in x-direction [m].
+float64 length_x
+
+# Length in y-direction [m].
+float64 length_y
+
+# Pose of the grid map center in the frame defined in `header` [m].
+geometry_msgs/Pose pose
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+

--- a/packages/rosmsg-msgs-common/msgdefs/ros2jazzy/grid_map_msgs/msg/GridMap.msg
+++ b/packages/rosmsg-msgs-common/msgdefs/ros2jazzy/grid_map_msgs/msg/GridMap.msg
@@ -1,0 +1,264 @@
+# Grid map header
+GridMapInfo info
+
+# Grid map layer names.
+string[] layers
+
+# Grid map basic layer names (optional). The basic layers
+# determine which layers from `layers` need to be valid
+# in order for a cell of the grid map to be valid.
+string[] basic_layers
+
+# Grid map data.
+std_msgs/Float32MultiArray[] data
+
+# Row start index (default 0).
+uint16 outer_start_index
+
+# Column start index (default 0).
+uint16 inner_start_index
+
+================================================================================
+MSG: grid_map_msgs/GridMapInfo
+# Header (time and frame)
+std_msgs/Header header
+
+# Resolution of the grid [m/cell].
+float64 resolution
+
+# Length in x-direction [m].
+float64 length_x
+
+# Length in y-direction [m].
+float64 length_y
+
+# Pose of the grid map center in the frame defined in `header` [m].
+geometry_msgs/Pose pose
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+
+================================================================================
+MSG: std_msgs/Float32MultiArray
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# Please look at the MultiArrayLayout message definition for
+# documentation on all multiarrays.
+
+MultiArrayLayout  layout        # specification of data layout
+float32[]         data          # array of data
+
+================================================================================
+MSG: std_msgs/MultiArrayLayout
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# The multiarray declares a generic multi-dimensional array of a
+# particular data type.  Dimensions are ordered from outer most
+# to inner most.
+#
+# Accessors should ALWAYS be written in terms of dimension stride
+# and specified outer-most dimension first.
+#
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]
+#
+# A standard, 3-channel 640x480 image with interleaved color channels
+# would be specified as:
+#
+# dim[0].label  = "height"
+# dim[0].size   = 480
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)
+# dim[1].label  = "width"
+# dim[1].size   = 640
+# dim[1].stride = 3*640 = 1920
+# dim[2].label  = "channel"
+# dim[2].size   = 3
+# dim[2].stride = 3
+#
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.
+
+MultiArrayDimension[] dim # Array of dimension properties
+uint32 data_offset        # padding bytes at front of data
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: std_msgs/MultiArrayLayout
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# The multiarray declares a generic multi-dimensional array of a
+# particular data type.  Dimensions are ordered from outer most
+# to inner most.
+#
+# Accessors should ALWAYS be written in terms of dimension stride
+# and specified outer-most dimension first.
+#
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]
+#
+# A standard, 3-channel 640x480 image with interleaved color channels
+# would be specified as:
+#
+# dim[0].label  = "height"
+# dim[0].size   = 480
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)
+# dim[1].label  = "width"
+# dim[1].size   = 640
+# dim[1].stride = 3*640 = 1920
+# dim[2].label  = "channel"
+# dim[2].size   = 3
+# dim[2].stride = 3
+#
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.
+
+MultiArrayDimension[] dim # Array of dimension properties
+uint32 data_offset        # padding bytes at front of data
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+
+================================================================================
+MSG: std_msgs/MultiArrayDimension
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension
+
+

--- a/packages/rosmsg-msgs-common/msgdefs/ros2jazzy/grid_map_msgs/msg/GridMapInfo.msg
+++ b/packages/rosmsg-msgs-common/msgdefs/ros2jazzy/grid_map_msgs/msg/GridMapInfo.msg
@@ -1,0 +1,69 @@
+# Header (time and frame)
+std_msgs/Header header
+
+# Resolution of the grid [m/cell].
+float64 resolution
+
+# Length in x-direction [m].
+float64 length_x
+
+# Length in y-direction [m].
+float64 length_y
+
+# Pose of the grid map center in the frame defined in `header` [m].
+geometry_msgs/Pose pose
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+
+# Two-integer timestamp that is expressed as seconds and nanoseconds.
+builtin_interfaces/Time stamp
+
+# Transform frame with which this data is associated.
+string frame_id
+
+
+================================================================================
+MSG: geometry_msgs/Pose
+# A representation of pose in free space, composed of position and orientation.
+
+Point position
+Quaternion orientation
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+
+================================================================================
+MSG: geometry_msgs/Point
+# This contains the position of a point in free space
+float64 x
+float64 y
+float64 z
+
+
+================================================================================
+MSG: geometry_msgs/Quaternion
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
+
+

--- a/packages/rosmsg-msgs-common/package.json
+++ b/packages/rosmsg-msgs-common/package.json
@@ -40,13 +40,15 @@
     "test:commonjs": "node -e \"require('./dist/index.js')\"",
     "test:esm": "test/testEsmImport.sh",
     "test:types": "tsc --noEmit ./dist/index.d.ts",
-    "test": "yarn test:commonjs && yarn test:esm && yarn test:types"
+    "test": "yarn test:commonjs && yarn test:esm && yarn test:types",
+    "update:msgdefs:urls": "tsx scripts/update-msgdefs-from-urls.ts"
   },
   "devDependencies": {
     "@types/node": "^24.0.8",
     "esbuild": "^0.25.4",
     "esbuild-runner": "^2.2.2",
     "prettier": "^3.6.2",
+    "tsx": "^4.19.0",
     "typescript": "^5.8.3"
   },
   "dependencies": {

--- a/packages/rosmsg-msgs-common/scripts/extra-message-def-urls.txt
+++ b/packages/rosmsg-msgs-common/scripts/extra-message-def-urls.txt
@@ -1,0 +1,2 @@
+https://raw.githubusercontent.com/ANYbotics/grid_map/refs/heads/master/grid_map_msgs/msg/GridMapInfo.msg
+https://raw.githubusercontent.com/ANYbotics/grid_map/refs/heads/master/grid_map_msgs/msg/GridMap.msg

--- a/packages/rosmsg-msgs-common/scripts/gendeps.ts
+++ b/packages/rosmsg-msgs-common/scripts/gendeps.ts
@@ -1,0 +1,135 @@
+import { parse } from "@foxglove/rosmsg";
+import { readFile, readdir } from "fs/promises";
+import { join, sep, resolve } from "path";
+
+type TypeInformation = {
+  fullType: string;
+  complexTypes: string[];
+  msgDefinitionString: string;
+};
+
+async function main() {
+  if (process.argv.length !== 4) {
+    console.error("Usage: gendeps <msgdefs-dir> <msg-file>");
+    process.exit(1);
+  }
+
+  const inputRootPath = process.argv[2]!;
+  const inputFilename = process.argv[3]!;
+  // Resolve paths relative to current working directory
+  const rootPath = resolve(process.cwd(), inputRootPath);
+  const filename = resolve(process.cwd(), inputFilename);
+  const fullTypeName = getFullTypeFromFilename(filename, rootPath);
+
+  const res = await loadType(fullTypeName, rootPath, getPackageName(fullTypeName));
+  console.log(res.msgDefinitionString);
+
+  const complexTypes = res.complexTypes;
+  const seenTypes = new Set<string>();
+  seenTypes.add(res.fullType);
+
+  while (complexTypes.length > 0) {
+    const complexType = complexTypes.shift()!;
+    const curRes = await loadType(complexType, rootPath, getPackageName(complexType));
+
+    console.log("================================================================================");
+    console.log(`MSG: ${curRes.fullType}`);
+    console.log(curRes.msgDefinitionString);
+
+    for (const complexSubType of curRes.complexTypes) {
+      if (!seenTypes.has(complexSubType)) {
+        complexTypes.push(complexSubType);
+        seenTypes.add(complexSubType);
+      }
+    }
+  }
+}
+function getFullType(typeName: string, currentPackage: string | undefined): string {
+  if (typeName.includes("/")) {
+    return typeName;
+  }
+  if (!currentPackage) {
+    throw new Error(`Cannot resolve relative type name ${typeName}`);
+  }
+  return `${currentPackage}/${typeName}`;
+}
+
+function getPackageName(typeName: string): string {
+  return typeName.split("/")[0]!;
+}
+
+function getBaseType(typeName: string): string {
+  return typeName.split("/").pop()!;
+}
+
+async function loadType(
+  typeName: string,
+  rootPath: string,
+  currentPackage: string,
+): Promise<TypeInformation> {
+  const fullType = getFullType(typeName, currentPackage);
+  const packageName = getPackageName(fullType);
+  const baseType = getBaseType(typeName);
+  const msgDefinitionString = await readFileFromBaseDir(
+    `${baseType}.msg`,
+    join(rootPath, packageName),
+  );
+  if (msgDefinitionString == undefined) {
+    throw new Error(
+      `Failed to load definition for type ${typeName} (current package: ${currentPackage})`,
+    );
+  }
+
+  const complexTypes: string[] = [];
+  const msgDefinitions = parse(msgDefinitionString, { ros2: true, skipTypeFixup: true });
+  // Ensure first definition is named with the full type for proper namespace resolution
+  if (msgDefinitions[0] && msgDefinitions[0].name == undefined) {
+    msgDefinitions[0].name = fullType;
+  }
+  for (const msgdef of msgDefinitions) {
+    const containerPackage = msgdef.name ? getPackageName(msgdef.name) : currentPackage;
+    for (const definition of msgdef.definitions) {
+      if (definition.isComplex === true && !complexTypes.includes(definition.type)) {
+        complexTypes.push(getFullType(definition.type, containerPackage));
+      }
+    }
+  }
+
+  return { fullType, complexTypes, msgDefinitionString };
+}
+
+function getFullTypeFromFilename(filename: string, rootPath: string): string {
+  const pathParts = rootPath.split(sep);
+  const filenameParts = filename.replace(/\.msg$/, "").split(sep);
+
+  // Remove pathParts from msgFileParts
+  for (const pathPart of pathParts) {
+    if (pathPart !== filenameParts[0]) {
+      console.log(`${pathPart} !== ${filenameParts[0]!}`);
+      throw new Error(`<msg-file> "${filename}" must be under <msgdefs-dir> "${rootPath}"`);
+    }
+    filenameParts.shift();
+  }
+
+  const packageName = filenameParts.shift()!;
+  const baseType = filenameParts[filenameParts.length - 1]!;
+  return `${packageName}/${baseType}`;
+}
+
+// Recursively search inside a directory for a file with a given name
+async function readFileFromBaseDir(filename: string, baseDir: string): Promise<string | undefined> {
+  const files = await readdir(baseDir, { withFileTypes: true });
+  for (const file of files) {
+    if (file.isDirectory()) {
+      const contents = await readFileFromBaseDir(filename, join(baseDir, file.name));
+      if (contents != undefined) {
+        return contents;
+      }
+    } else if (file.isFile() && file.name === filename) {
+      return await readFile(join(baseDir, file.name), { encoding: "utf8" });
+    }
+  }
+  return undefined;
+}
+
+void main();

--- a/packages/rosmsg-msgs-common/scripts/update-msgdefs-from-urls.ts
+++ b/packages/rosmsg-msgs-common/scripts/update-msgdefs-from-urls.ts
@@ -1,0 +1,170 @@
+import { spawn } from "child_process";
+import { createWriteStream, existsSync } from "fs";
+import { mkdir, readFile, readdir, writeFile } from "fs/promises";
+import * as http from "http";
+import * as https from "https";
+import { tmpdir } from "os";
+import { join, resolve, dirname } from "path";
+
+type DownloadedMsg = {
+  url: string;
+  packageName: string;
+  msgRelativePath: string; // e.g., grid_map_msgs/msg/GridMap.msg
+  tempFilePath: string;
+};
+
+async function main() {
+  const packageRoot = process.cwd();
+  const repoRoot = resolve(packageRoot, "../..");
+  const urlsListPath = resolve(packageRoot, "scripts/extra-message-def-urls.txt");
+  const urlsListContent = await readFile(urlsListPath, { encoding: "utf8" });
+  const urls = urlsListContent
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+  if (urls.length === 0) {
+    console.error("No URLs found in list.");
+    process.exit(1);
+  }
+
+  const tmpBase = resolve(tmpdir(), `ros-msgdefs-${Date.now()}`);
+  await mkdir(tmpBase, { recursive: true });
+
+  const downloads: DownloadedMsg[] = [];
+  for (const url of urls) {
+    const parsed = new URL(url);
+    const path = parsed.pathname;
+    const match = /\/([^/#?]+)\/msg\/(.+\.msg)$/.exec(path);
+    if (!match) {
+      console.warn(`Skipping URL without /<pkg>/msg/*.msg structure: ${url}`);
+      continue;
+    }
+    const packageName = match[1]!;
+    const msgFileRest = match[2]!; // e.g., GridMap.msg or nested/path.msg
+    const msgRelativePath = join(packageName, "msg", msgFileRest);
+    const destPath = resolve(tmpBase, msgRelativePath);
+    await mkdir(dirname(destPath), { recursive: true });
+    await downloadToFile(url, destPath);
+    downloads.push({ url, packageName, msgRelativePath, tempFilePath: destPath });
+  }
+
+  if (downloads.length === 0) {
+    console.error("No downloadable .msg files found. Nothing to do.");
+    process.exit(1);
+  }
+
+  const msgdefsRoot = resolve(packageRoot, "msgdefs");
+  const ros2Roots = await listRos2Roots(msgdefsRoot);
+  if (ros2Roots.length === 0) {
+    console.error("No ros2* directories found under packages/rosmsg-msgs-common/msgdefs");
+    process.exit(1);
+  }
+
+  for (const ros2Root of ros2Roots) {
+    for (const item of downloads) {
+      const targetMsgPath = resolve(ros2Root, item.msgRelativePath);
+      await mkdir(dirname(targetMsgPath), { recursive: true });
+
+      // Stage downloaded content at target path so gendeps can resolve <msg-file> under <msgdefs-dir>
+      const originalContent = existsSync(targetMsgPath)
+        ? await readFile(targetMsgPath, { encoding: "utf8" }).catch(() => undefined)
+        : undefined;
+      const downloadedContent = await readFile(item.tempFilePath, { encoding: "utf8" });
+      await writeFile(targetMsgPath, downloadedContent, { encoding: "utf8" });
+
+      try {
+        const unrolled = await runGendeps(repoRoot, ros2Root, targetMsgPath);
+        await writeFile(targetMsgPath, unrolled, { encoding: "utf8" });
+        process.stdout.write(
+          `Updated ${pathFromRepo(repoRoot, targetMsgPath)} (from ${item.url})\n`,
+        );
+      } catch (err) {
+        if (originalContent != undefined) {
+          await writeFile(targetMsgPath, originalContent, { encoding: "utf8" }).catch(
+            console.error,
+          );
+        }
+        console.error(
+          `Failed to generate dependencies for ${pathFromRepo(
+            repoRoot,
+            targetMsgPath,
+          )}: ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+}
+
+async function listRos2Roots(baseDir: string): Promise<string[]> {
+  const entries = await readdir(baseDir, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory() && e.name.startsWith("ros2"))
+    .map((e) => resolve(baseDir, e.name));
+}
+
+function pathFromRepo(repoRoot: string, absPath: string): string {
+  return absPath.startsWith(repoRoot) ? absPath.slice(repoRoot.length + 1) : absPath;
+}
+
+async function downloadToFile(url: string, destPath: string): Promise<void> {
+  const client = url.startsWith("https:") ? https : http;
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const file = createWriteStream(destPath);
+    const req = client.get(url, (res) => {
+      if (
+        res.statusCode != undefined &&
+        res.statusCode >= 300 &&
+        res.statusCode < 400 &&
+        res.headers.location
+      ) {
+        // Follow redirects
+        downloadToFile(res.headers.location, destPath).then(resolvePromise, rejectPromise);
+        res.resume();
+        return;
+      }
+      if (res.statusCode !== 200) {
+        file.close();
+        rejectPromise(new Error(`HTTP ${res.statusCode ?? "unknown"} for ${url}`));
+        res.resume();
+        return;
+      }
+      res.pipe(file);
+      file.on("finish", () => {
+        file.close(() => {
+          resolvePromise();
+        });
+      });
+    });
+    req.on("error", (err) => {
+      file.close();
+      rejectPromise(err);
+    });
+  });
+}
+
+async function runGendeps(repoRoot: string, msgdefsRoot: string, msgFile: string): Promise<string> {
+  return await new Promise<string>((resolvePromise, rejectPromise) => {
+    const proc = spawn(
+      "node",
+      ["-r", "esbuild-runner/register", "scripts/gendeps.ts", msgdefsRoot, msgFile],
+      { cwd: resolve(repoRoot, "packages/rosmsg-msgs-common"), stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d) => (stdout += String(d)));
+    proc.stderr.on("data", (d) => (stderr += String(d)));
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolvePromise(stdout);
+      } else {
+        rejectPromise(new Error(stderr || `gendeps exited with code ${code ?? "unknown"}`));
+      }
+    });
+    proc.on("error", (err) => {
+      rejectPromise(err);
+    });
+  });
+}
+
+void main();

--- a/packages/rosmsg-msgs-common/tsconfig.json
+++ b/packages/rosmsg-msgs-common/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["./src/**/*.ts"],
+  "include": ["./src/**/*.ts", "./scripts/**/*.ts"],
   "compilerOptions": {
     "target": "es2020",
     "lib": ["dom", "es2020"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,6 +1007,7 @@ __metadata:
     esbuild: "npm:^0.25.4"
     esbuild-runner: "npm:^2.2.2"
     prettier: "npm:^3.6.2"
+    tsx: "npm:^4.19.0"
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
@@ -4170,7 +4171,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.25.4":
+"esbuild@npm:^0.25.4, esbuild@npm:~0.25.0":
   version: 0.25.9
   resolution: "esbuild@npm:0.25.9"
   dependencies:
@@ -4935,7 +4936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.3":
+"fsevents@npm:^2.3.3, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -4945,7 +4946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -5046,6 +5047,15 @@ __metadata:
     es-errors: "npm:^1.3.0"
     get-intrinsic: "npm:^1.2.6"
   checksum: 10c0/d6a7d6afca375779a4b307738c9e80dbf7afc0bdbe5948768d54ab9653c865523d8920e670991a925936eb524b7cb6a6361d199a760b21d0ca7620194455aa4b
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.5":
+  version: 4.10.1
+  resolution: "get-tsconfig@npm:4.10.1"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/7f8e3dabc6a49b747920a800fb88e1952fef871cdf51b79e98db48275a5de6cdaf499c55ee67df5fa6fe7ce65f0063e26de0f2e53049b408c585aa74d39ffa21
   languageName: node
   linkType: hard
 
@@ -8192,6 +8202,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.20.0, resolve@npm:^1.22.4":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
@@ -9226,6 +9243,22 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 10c0/02f19e458ec78ead8fffbf711f834ad8ecd2cc6ade4ec0320790713dccc0a412b99e7fd907c4cda2a1dc602c75db6f12e0108e87a5afad4b2f9e90a24cabd5a2
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.19.0":
+  version: 4.20.5
+  resolution: "tsx@npm:4.20.5"
+  dependencies:
+    esbuild: "npm:~0.25.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/70f9bf746be69281312a369c712902dbf9bcbdd9db9184a4859eb4859c36ef0c5a6d79b935c1ec429158ee73fd6584089400ae8790345dae34c5b0222bdb94f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changelog
Add script to incorporate additional message definitions from additional ros sources.

### Docs
None

### Description
Add back the gendeps script to generated unrolled message definitions for ros2 messages as well as some wrappers for downloading non-standard message definitions and updating all the ros2 subfolders with those messages.

I'm not sure if this is the right approach but it does seem to work. If we don't want this stuff in the `rosmsg-msgs-common` package directly we could either move it up into the parent package or make a new package. Nothing in the `scripts` directory should be included in the build rosmsg-msgs-common npm package though so I think that should address the concerns that led to the removal of the `gendeps` script in the first place.