### PR TITLE
make isTime require sec and nsec to be numbers

### DIFF
--- a/packages/rostime/src/timeUtils.test.ts
+++ b/packages/rostime/src/timeUtils.test.ts
@@ -16,6 +16,20 @@ describe("isTime", () => {
     expect(rostime.isTime({ sec: 1, nsec: 0 })).toEqual(true);
     expect(rostime.isTime({ sec: 1624947142, nsec: 42 })).toEqual(true);
   });
+
+  it.each([
+    ["sec is bigint", { sec: 1n, nsec: 0 }],
+    ["nsec is bigint", { sec: 0, nsec: 1n }],
+    ["sec and nsec are bigint", { sec: 1n, nsec: 1n }],
+    ["sec and nsec are strings", { sec: "1", nsec: "1" }],
+    ["sec and nsec are undefined", { sec: undefined, nsec: undefined }],
+    ["sec is undefined", { sec: undefined, nsec: 0 }],
+    ["nsec is undefined", { sec: 0, nsec: undefined }],
+    ["sec is null", { sec: null, nsec: 0 }],
+    ["nsec is null", { sec: 0, nsec: null }],
+  ] as const)("returns false when %s", (_caseName, obj) => {
+    expect(rostime.isTime(obj)).toEqual(false);
+  });
 });
 
 describe("toRFC3339String", () => {

--- a/packages/rostime/src/timeUtils.ts
+++ b/packages/rostime/src/timeUtils.ts
@@ -23,8 +23,8 @@ export function isTime(obj?: unknown): obj is Time {
   return (
     typeof obj === "object" &&
     !!obj &&
-    "sec" in obj &&
-    "nsec" in obj &&
+    typeof (obj as Time).sec === "number" &&
+    typeof (obj as Time).nsec === "number" &&
     Object.getOwnPropertyNames(obj).length === 2
   );
 }


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs
None

### Description
Tightens the checks in `isTime` to require both `sec` and `nsec` fields to be `number` types. Prior to this PR, there was no such check and isTime would return true for any object that would have sec and nsec fields, regardless of their type.