### PR TITLE
Bump @foxglove/rostime from 1.1.2 to 1.1.3

### DIFF
--- a/packages/rostime/package.json
+++ b/packages/rostime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rostime",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "ROS Time and Duration primitives and helper methods",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Changelog
- make isTime require sec and nsec to be numbers (#130)
