### PR TITLE
report incomplete message reads to reader callers

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -84,4 +84,12 @@ module.exports = tseslint.config(
       },
     },
   },
+  {
+    files: ["packages/rosmsg2-serialization/**"],
+    languageOptions: {
+      parserOptions: {
+        project: "packages/rosmsg2-serialization/tsconfig.eslint.json",
+      },
+    },
+  },
 );

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -82,8 +82,8 @@ describe("MessageReader", () => {
       const result = reader.readMessage(exactPayload);
 
       expect(result).toEqual({ firstName: "foo", lastName: "bar", age: 5 });
-      expect(reader.lastReadByteLength).toBe(exactPayload.byteLength);
-      expect(reader.lastReadHadTrailingBytes).toBe(false);
+      expect(reader.lastReadByteLength()).toBe(exactPayload.byteLength);
+      expect(reader.lastReadHadTrailingBytes()).toBe(false);
     });
 
     it("flags trailing bytes when the payload is larger than the schema consumes", () => {
@@ -92,8 +92,8 @@ describe("MessageReader", () => {
       const buffer = Buffer.concat([exactPayload, trailing]);
 
       expect(reader.readMessage(buffer)).toEqual({ firstName: "foo", lastName: "bar", age: 5 });
-      expect(reader.lastReadByteLength).toBe(exactPayload.byteLength);
-      expect(reader.lastReadHadTrailingBytes).toBe(true);
+      expect(reader.lastReadByteLength()).toBe(exactPayload.byteLength);
+      expect(reader.lastReadHadTrailingBytes()).toBe(true);
     });
 
     it("clears trailing byte state after the next exact-fit decode", () => {
@@ -102,12 +102,12 @@ describe("MessageReader", () => {
       const buffer = Buffer.concat([exactPayload, trailing]);
 
       reader.readMessage(buffer);
-      expect(reader.lastReadByteLength).toBe(exactPayload.byteLength);
-      expect(reader.lastReadHadTrailingBytes).toBe(true);
+      expect(reader.lastReadByteLength()).toBe(exactPayload.byteLength);
+      expect(reader.lastReadHadTrailingBytes()).toBe(true);
 
       reader.readMessage(exactPayload);
-      expect(reader.lastReadByteLength).toBe(exactPayload.byteLength);
-      expect(reader.lastReadHadTrailingBytes).toBe(false);
+      expect(reader.lastReadByteLength()).toBe(exactPayload.byteLength);
+      expect(reader.lastReadHadTrailingBytes()).toBe(false);
     });
   });
 });

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -67,4 +67,43 @@ describe("MessageReader", () => {
       output.firstName = "boooo";
     }).toThrow();
   });
+
+  describe("hasTrailingBytes", () => {
+    const msgDef = `string firstName\nstring lastName\nuint16 age`;
+    const exactPayload = Buffer.concat([
+      getStringBuffer("foo"),
+      getStringBuffer("bar"),
+      new Uint8Array([0x05, 0x00]),
+    ]);
+
+    it("reports zero trailing bytes for an exact-fit decode", () => {
+      const reader = new MessageReader(parseMessageDefinition(msgDef));
+
+      const result = reader.readMessage(exactPayload);
+
+      expect(result).toEqual({ firstName: "foo", lastName: "bar", age: 5 });
+      expect(reader.hasTrailingBytes).toBe(false);
+    });
+
+    it("flags trailing bytes when the payload is larger than the schema consumes", () => {
+      const reader = new MessageReader(parseMessageDefinition(msgDef));
+      const trailing = new Uint8Array([0xff, 0xff, 0xff, 0xff]);
+      const buffer = Buffer.concat([exactPayload, trailing]);
+
+      expect(reader.readMessage(buffer)).toEqual({ firstName: "foo", lastName: "bar", age: 5 });
+      expect(reader.hasTrailingBytes).toBe(true);
+    });
+
+    it("clears trailing byte state after the next exact-fit decode", () => {
+      const reader = new MessageReader(parseMessageDefinition(msgDef));
+      const trailing = new Uint8Array([0xff, 0xff, 0xff, 0xff]);
+      const buffer = Buffer.concat([exactPayload, trailing]);
+
+      reader.readMessage(buffer);
+      expect(reader.hasTrailingBytes).toBe(true);
+
+      reader.readMessage(exactPayload);
+      expect(reader.hasTrailingBytes).toBe(false);
+    });
+  });
 });

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -68,7 +68,7 @@ describe("MessageReader", () => {
     }).toThrow();
   });
 
-  describe("hasTrailingBytes", () => {
+  describe("lastReadHadTrailingBytes", () => {
     const msgDef = `string firstName\nstring lastName\nuint16 age`;
     const exactPayload = Buffer.concat([
       getStringBuffer("foo"),
@@ -82,7 +82,7 @@ describe("MessageReader", () => {
       const result = reader.readMessage(exactPayload);
 
       expect(result).toEqual({ firstName: "foo", lastName: "bar", age: 5 });
-      expect(reader.hasTrailingBytes).toBe(false);
+      expect(reader.lastReadHadTrailingBytes).toBe(false);
     });
 
     it("flags trailing bytes when the payload is larger than the schema consumes", () => {
@@ -91,7 +91,7 @@ describe("MessageReader", () => {
       const buffer = Buffer.concat([exactPayload, trailing]);
 
       expect(reader.readMessage(buffer)).toEqual({ firstName: "foo", lastName: "bar", age: 5 });
-      expect(reader.hasTrailingBytes).toBe(true);
+      expect(reader.lastReadHadTrailingBytes).toBe(true);
     });
 
     it("clears trailing byte state after the next exact-fit decode", () => {
@@ -100,10 +100,10 @@ describe("MessageReader", () => {
       const buffer = Buffer.concat([exactPayload, trailing]);
 
       reader.readMessage(buffer);
-      expect(reader.hasTrailingBytes).toBe(true);
+      expect(reader.lastReadHadTrailingBytes).toBe(true);
 
       reader.readMessage(exactPayload);
-      expect(reader.hasTrailingBytes).toBe(false);
+      expect(reader.lastReadHadTrailingBytes).toBe(false);
     });
   });
 });

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -82,6 +82,7 @@ describe("MessageReader", () => {
       const result = reader.readMessage(exactPayload);
 
       expect(result).toEqual({ firstName: "foo", lastName: "bar", age: 5 });
+      expect(reader.lastReadByteLength).toBe(exactPayload.byteLength);
       expect(reader.lastReadHadTrailingBytes).toBe(false);
     });
 
@@ -91,6 +92,7 @@ describe("MessageReader", () => {
       const buffer = Buffer.concat([exactPayload, trailing]);
 
       expect(reader.readMessage(buffer)).toEqual({ firstName: "foo", lastName: "bar", age: 5 });
+      expect(reader.lastReadByteLength).toBe(exactPayload.byteLength);
       expect(reader.lastReadHadTrailingBytes).toBe(true);
     });
 
@@ -100,9 +102,11 @@ describe("MessageReader", () => {
       const buffer = Buffer.concat([exactPayload, trailing]);
 
       reader.readMessage(buffer);
+      expect(reader.lastReadByteLength).toBe(exactPayload.byteLength);
       expect(reader.lastReadHadTrailingBytes).toBe(true);
 
       reader.readMessage(exactPayload);
+      expect(reader.lastReadByteLength).toBe(exactPayload.byteLength);
       expect(reader.lastReadHadTrailingBytes).toBe(false);
     });
   });

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -331,14 +331,14 @@ export class MessageReader {
    * True when the most recent decode finished before reaching the end of the buffer. This can
    * signal a schema/payload version mismatch.
    */
-  get lastReadHadTrailingBytes(): boolean {
+  lastReadHadTrailingBytes(): boolean {
     return this.#lastReadHadTrailingBytes;
   }
 
   /**
    * Number of bytes consumed by the most recent decode.
    */
-  get lastReadByteLength(): number {
+  lastReadByteLength(): number {
     return this.#lastReadByteLength;
   }
 

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -329,7 +329,7 @@ export class MessageReader {
    * True when the most recent decode finished before reaching the end of the buffer. This can
    * signal a schema/payload version mismatch.
    */
-  hasTrailingBytes = false;
+  lastReadHadTrailingBytes = false;
 
   // takes an object message definition and returns
   // a message reader which can be used to read messages based
@@ -344,7 +344,7 @@ export class MessageReader {
   readMessage<T = unknown>(buffer: ArrayBufferView): T {
     const standardReaders = new StandardTypeReader(buffer);
     const value = new this.reader(standardReaders) as T;
-    this.hasTrailingBytes = standardReaders.offset < buffer.byteLength;
+    this.lastReadHadTrailingBytes = standardReaders.offset < buffer.byteLength;
     return value;
   }
 }

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -324,12 +324,23 @@ export const createParsers = ({
 
 export class MessageReader {
   reader: new (reader: StandardTypeReader) => unknown;
+  #lastReadByteLength = 0;
+  #lastReadHadTrailingBytes = false;
 
   /**
    * True when the most recent decode finished before reaching the end of the buffer. This can
    * signal a schema/payload version mismatch.
    */
-  lastReadHadTrailingBytes = false;
+  get lastReadHadTrailingBytes(): boolean {
+    return this.#lastReadHadTrailingBytes;
+  }
+
+  /**
+   * Number of bytes consumed by the most recent decode.
+   */
+  get lastReadByteLength(): number {
+    return this.#lastReadByteLength;
+  }
 
   // takes an object message definition and returns
   // a message reader which can be used to read messages based
@@ -344,7 +355,8 @@ export class MessageReader {
   readMessage<T = unknown>(buffer: ArrayBufferView): T {
     const standardReaders = new StandardTypeReader(buffer);
     const value = new this.reader(standardReaders) as T;
-    this.lastReadHadTrailingBytes = standardReaders.offset < buffer.byteLength;
+    this.#lastReadByteLength = standardReaders.offset;
+    this.#lastReadHadTrailingBytes = this.#lastReadByteLength < buffer.byteLength;
     return value;
   }
 }

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -325,6 +325,12 @@ export const createParsers = ({
 export class MessageReader {
   reader: new (reader: StandardTypeReader) => unknown;
 
+  /**
+   * True when the most recent decode finished before reaching the end of the buffer. This can
+   * signal a schema/payload version mismatch.
+   */
+  hasTrailingBytes = false;
+
   // takes an object message definition and returns
   // a message reader which can be used to read messages based
   // on the message definition
@@ -337,6 +343,8 @@ export class MessageReader {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   readMessage<T = unknown>(buffer: ArrayBufferView): T {
     const standardReaders = new StandardTypeReader(buffer);
-    return new this.reader(standardReaders) as T;
+    const value = new this.reader(standardReaders) as T;
+    this.hasTrailingBytes = standardReaders.offset < buffer.byteLength;
+    return value;
   }
 }

--- a/packages/rosmsg-serialization/tsconfig.json
+++ b/packages/rosmsg-serialization/tsconfig.json
@@ -2,6 +2,7 @@
 {
   "extends": "@foxglove/tsconfig/base.json",
   "include": ["./src/**/*"],
+  "exclude": ["./src/**/*.test.ts", "./src/fixtures/**/*"],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/esm",

--- a/packages/rosmsg2-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.test.ts
@@ -617,6 +617,7 @@ module builtin_interfaces {
         points: new Uint32Array(),
         texts: new Uint32Array(),
       });
+      expect(reader.lastReadByteLength).toBe(buffer.byteLength);
       expect(reader.lastReadHadTrailingBytes).toBe(false);
     });
 
@@ -630,6 +631,7 @@ module builtin_interfaces {
         points: new Uint32Array(),
         texts: new Uint32Array(),
       });
+      expect(reader.lastReadByteLength).toBe(buffer.byteLength - trailing.length);
       expect(reader.lastReadHadTrailingBytes).toBe(true);
     });
 
@@ -646,9 +648,11 @@ module builtin_interfaces {
       const reader = new MessageReader(parseMessageDefinition(annotationsLikeDef, { ros2: true }));
 
       reader.readMessage(trailingBuffer);
+      expect(reader.lastReadByteLength).toBe(exactBuffer.byteLength);
       expect(reader.lastReadHadTrailingBytes).toBe(true);
 
       reader.readMessage(exactBuffer);
+      expect(reader.lastReadByteLength).toBe(exactBuffer.byteLength);
       expect(reader.lastReadHadTrailingBytes).toBe(false);
     });
   });

--- a/packages/rosmsg2-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.test.ts
@@ -591,7 +591,7 @@ module builtin_interfaces {
     },
   );
 
-  describe("hasTrailingBytes", () => {
+  describe("lastReadHadTrailingBytes", () => {
     // Mirrors the FG-14433 reproduction shape: an `ImageAnnotations`-style schema with three empty
     // sequences. The exact-fit case is 16 bytes (4-byte CDR header + three 4-byte zero-length
     // prefixes). The skewed case appends 12 bytes of unused payload — the same shape produced when
@@ -617,7 +617,7 @@ module builtin_interfaces {
         points: new Uint32Array(),
         texts: new Uint32Array(),
       });
-      expect(reader.hasTrailingBytes).toBe(false);
+      expect(reader.lastReadHadTrailingBytes).toBe(false);
     });
 
     it("flags trailing bytes when the payload is larger than the schema consumes", () => {
@@ -630,7 +630,7 @@ module builtin_interfaces {
         points: new Uint32Array(),
         texts: new Uint32Array(),
       });
-      expect(reader.hasTrailingBytes).toBe(true);
+      expect(reader.lastReadHadTrailingBytes).toBe(true);
     });
 
     it("clears trailing byte state after the next exact-fit decode", () => {
@@ -646,10 +646,10 @@ module builtin_interfaces {
       const reader = new MessageReader(parseMessageDefinition(annotationsLikeDef, { ros2: true }));
 
       reader.readMessage(trailingBuffer);
-      expect(reader.hasTrailingBytes).toBe(true);
+      expect(reader.lastReadHadTrailingBytes).toBe(true);
 
       reader.readMessage(exactBuffer);
-      expect(reader.hasTrailingBytes).toBe(false);
+      expect(reader.lastReadHadTrailingBytes).toBe(false);
     });
   });
 });

--- a/packages/rosmsg2-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.test.ts
@@ -590,4 +590,66 @@ module builtin_interfaces {
       );
     },
   );
+
+  describe("hasTrailingBytes", () => {
+    // Mirrors the FG-14433 reproduction shape: an `ImageAnnotations`-style schema with three empty
+    // sequences. The exact-fit case is 16 bytes (4-byte CDR header + three 4-byte zero-length
+    // prefixes). The skewed case appends 12 bytes of unused payload — the same shape produced when
+    // a 3.2.5 publisher (with prepended `Time timestamp` field) writes against a 3.2.4 schema.
+    const annotationsLikeDef = `
+      uint32[] circles
+      uint32[] points
+      uint32[] texts
+    `;
+    const cdrHeader = [0x00, 0x01, 0x00, 0x00];
+    const threeZeroLengthArrays = [
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+
+    it("reports zero trailing bytes for an exact-fit decode", () => {
+      const buffer = Uint8Array.from([...cdrHeader, ...threeZeroLengthArrays]);
+      const reader = new MessageReader(parseMessageDefinition(annotationsLikeDef, { ros2: true }));
+
+      const result = reader.readMessage(buffer);
+
+      expect(result).toEqual({
+        circles: new Uint32Array(),
+        points: new Uint32Array(),
+        texts: new Uint32Array(),
+      });
+      expect(reader.hasTrailingBytes).toBe(false);
+    });
+
+    it("flags trailing bytes when the payload is larger than the schema consumes", () => {
+      const trailing = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+      const buffer = Uint8Array.from([...cdrHeader, ...threeZeroLengthArrays, ...trailing]);
+      const reader = new MessageReader(parseMessageDefinition(annotationsLikeDef, { ros2: true }));
+
+      expect(reader.readMessage(buffer)).toEqual({
+        circles: new Uint32Array(),
+        points: new Uint32Array(),
+        texts: new Uint32Array(),
+      });
+      expect(reader.hasTrailingBytes).toBe(true);
+    });
+
+    it("clears trailing byte state after the next exact-fit decode", () => {
+      const exactBuffer = Uint8Array.from([...cdrHeader, ...threeZeroLengthArrays]);
+      const trailingBuffer = Uint8Array.from([
+        ...cdrHeader,
+        ...threeZeroLengthArrays,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+      ]);
+      const reader = new MessageReader(parseMessageDefinition(annotationsLikeDef, { ros2: true }));
+
+      reader.readMessage(trailingBuffer);
+      expect(reader.hasTrailingBytes).toBe(true);
+
+      reader.readMessage(exactBuffer);
+      expect(reader.hasTrailingBytes).toBe(false);
+    });
+  });
 });

--- a/packages/rosmsg2-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.test.ts
@@ -617,8 +617,8 @@ module builtin_interfaces {
         points: new Uint32Array(),
         texts: new Uint32Array(),
       });
-      expect(reader.lastReadByteLength).toBe(buffer.byteLength);
-      expect(reader.lastReadHadTrailingBytes).toBe(false);
+      expect(reader.lastReadByteLength()).toBe(buffer.byteLength);
+      expect(reader.lastReadHadTrailingBytes()).toBe(false);
     });
 
     it("flags trailing bytes when the payload is larger than the schema consumes", () => {
@@ -631,8 +631,8 @@ module builtin_interfaces {
         points: new Uint32Array(),
         texts: new Uint32Array(),
       });
-      expect(reader.lastReadByteLength).toBe(buffer.byteLength - trailing.length);
-      expect(reader.lastReadHadTrailingBytes).toBe(true);
+      expect(reader.lastReadByteLength()).toBe(buffer.byteLength - trailing.length);
+      expect(reader.lastReadHadTrailingBytes()).toBe(true);
     });
 
     it("clears trailing byte state after the next exact-fit decode", () => {
@@ -648,12 +648,12 @@ module builtin_interfaces {
       const reader = new MessageReader(parseMessageDefinition(annotationsLikeDef, { ros2: true }));
 
       reader.readMessage(trailingBuffer);
-      expect(reader.lastReadByteLength).toBe(exactBuffer.byteLength);
-      expect(reader.lastReadHadTrailingBytes).toBe(true);
+      expect(reader.lastReadByteLength()).toBe(exactBuffer.byteLength);
+      expect(reader.lastReadHadTrailingBytes()).toBe(true);
 
       reader.readMessage(exactBuffer);
-      expect(reader.lastReadByteLength).toBe(exactBuffer.byteLength);
-      expect(reader.lastReadHadTrailingBytes).toBe(false);
+      expect(reader.lastReadByteLength()).toBe(exactBuffer.byteLength);
+      expect(reader.lastReadHadTrailingBytes()).toBe(false);
     });
   });
 });

--- a/packages/rosmsg2-serialization/src/MessageReader.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.ts
@@ -49,7 +49,7 @@ export class MessageReader<T = unknown> {
    * True when the most recent decode finished before reaching the end of the buffer. CDR ignores
    * trailing bytes by design, so this can signal a schema/payload version mismatch.
    */
-  public hasTrailingBytes = false;
+  public lastReadHadTrailingBytes = false;
 
   public constructor(definitions: MessageDefinition[], options: MessageReaderOptions = {}) {
     const { timeType = "sec,nanosec" } = options;
@@ -73,7 +73,7 @@ export class MessageReader<T = unknown> {
   public readMessage<R = T>(buffer: ArrayBufferView): R {
     const reader = new CdrReader(buffer);
     const value = this.#readComplexType(this.#rootDefinition, reader) as R;
-    this.hasTrailingBytes = !reader.isAtEnd();
+    this.lastReadHadTrailingBytes = !reader.isAtEnd();
     return value;
   }
 

--- a/packages/rosmsg2-serialization/src/MessageReader.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.ts
@@ -43,13 +43,24 @@ export type MessageReaderOptions = {
 export class MessageReader<T = unknown> {
   #rootDefinition: MessageDefinitionField[];
   #definitions: Map<string, MessageDefinitionField[]>;
+  #lastReadByteLength = 0;
+  #lastReadHadTrailingBytes = false;
   #useRos1Time: boolean;
 
   /**
    * True when the most recent decode finished before reaching the end of the buffer. CDR ignores
    * trailing bytes by design, so this can signal a schema/payload version mismatch.
    */
-  public lastReadHadTrailingBytes = false;
+  public get lastReadHadTrailingBytes(): boolean {
+    return this.#lastReadHadTrailingBytes;
+  }
+
+  /**
+   * Number of bytes consumed by the most recent decode.
+   */
+  public get lastReadByteLength(): number {
+    return this.#lastReadByteLength;
+  }
 
   public constructor(definitions: MessageDefinition[], options: MessageReaderOptions = {}) {
     const { timeType = "sec,nanosec" } = options;
@@ -73,7 +84,8 @@ export class MessageReader<T = unknown> {
   public readMessage<R = T>(buffer: ArrayBufferView): R {
     const reader = new CdrReader(buffer);
     const value = this.#readComplexType(this.#rootDefinition, reader) as R;
-    this.lastReadHadTrailingBytes = !reader.isAtEnd();
+    this.#lastReadByteLength = reader.decodedBytes;
+    this.#lastReadHadTrailingBytes = this.#lastReadByteLength < buffer.byteLength;
     return value;
   }
 

--- a/packages/rosmsg2-serialization/src/MessageReader.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.ts
@@ -51,14 +51,14 @@ export class MessageReader<T = unknown> {
    * True when the most recent decode finished before reaching the end of the buffer. CDR ignores
    * trailing bytes by design, so this can signal a schema/payload version mismatch.
    */
-  public get lastReadHadTrailingBytes(): boolean {
+  public lastReadHadTrailingBytes(): boolean {
     return this.#lastReadHadTrailingBytes;
   }
 
   /**
    * Number of bytes consumed by the most recent decode.
    */
-  public get lastReadByteLength(): number {
+  public lastReadByteLength(): number {
     return this.#lastReadByteLength;
   }
 

--- a/packages/rosmsg2-serialization/src/MessageReader.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.ts
@@ -45,6 +45,12 @@ export class MessageReader<T = unknown> {
   #definitions: Map<string, MessageDefinitionField[]>;
   #useRos1Time: boolean;
 
+  /**
+   * True when the most recent decode finished before reaching the end of the buffer. CDR ignores
+   * trailing bytes by design, so this can signal a schema/payload version mismatch.
+   */
+  public hasTrailingBytes = false;
+
   public constructor(definitions: MessageDefinition[], options: MessageReaderOptions = {}) {
     const { timeType = "sec,nanosec" } = options;
 
@@ -66,7 +72,9 @@ export class MessageReader<T = unknown> {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   public readMessage<R = T>(buffer: ArrayBufferView): R {
     const reader = new CdrReader(buffer);
-    return this.#readComplexType(this.#rootDefinition, reader) as R;
+    const value = this.#readComplexType(this.#rootDefinition, reader) as R;
+    this.hasTrailingBytes = !reader.isAtEnd();
+    return value;
   }
 
   #readComplexType(

--- a/packages/rosmsg2-serialization/tsconfig.eslint.json
+++ b/packages/rosmsg2-serialization/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/**/*.ts"],
+  "exclude": []
+}

--- a/packages/rosmsg2-serialization/tsconfig.json
+++ b/packages/rosmsg2-serialization/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["./src/**/*.ts"],
+  "exclude": ["./src/**/*.test.ts"],
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2020",


### PR DESCRIPTION
## Summary
- Add `lastReadHadTrailingBytes()` and `lastReadByteLength()` methods to ROS 1 and ROS 2 message readers so callers can detect trailing bytes or compare the consumed byte count with the original payload length.
- Preserve the existing `readMessage` return value and avoid a per-message result object allocation by storing the latest read state privately on the reader and refreshing it after each read.
- Add regression coverage for exact-fit, trailing-byte, and state-reset decodes, including the number of bytes consumed by each read.

## Why
A mixed-version ROS graph can produce recordings where the schema embedded in the MCAP does not describe the raw message bytes. In the FG-14433 reproduction, a publisher built against `foxglove_msgs` 3.2.5 sends `ImageAnnotations` messages with fields that do not exist in 3.2.4. A recorder built against 3.2.4 embeds the older `.msg` definition in the MCAP, but rosbag2 still writes the raw CDR bytes it receives from the newer publisher.

When the reader decodes those bytes with the older schema, it can successfully consume the prefix that still matches the schema and then stop before the end of the payload. That produces a valid-looking decoded value instead of a deserialization exception, so downstream consumers can mistake the result for empty or missing data.

Trailing bytes are the strongest signal for this class of version mismatch because a schema/payload pair that agrees should consume the whole message buffer. Field values can still look valid, topic presence only proves bytes exist, and short buffers already fail through the normal read path. The trailing-byte method covers the common boolean check, while the byte-length method exposes the exact consumed count for callers that need to report or compare it themselves.

## Tests
All tests are automated tests.

