### PR TITLE
bump serialization package version numbers

### DIFF
--- a/packages/rosmsg-serialization/package.json
+++ b/packages/rosmsg-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg-serialization",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "ROS 1 message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [

--- a/packages/rosmsg2-serialization/package.json
+++ b/packages/rosmsg2-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg2-serialization",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "ROS 2 message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump @foxglove/rosmsg-serialization to 2.1.0
- bump @foxglove/rosmsg2-serialization to 3.1.0

## Validation
- yarn workspaces foreach -Rp --topological-dev --from @foxglove/rosmsg-serialization run build
- yarn workspaces foreach -Rp --topological-dev --from @foxglove/rosmsg2-serialization run build
- yarn lint:ci packages/rosmsg-serialization
- yarn lint:ci packages/rosmsg2-serialization
- yarn workspace @foxglove/rosmsg-serialization test
- yarn workspace @foxglove/rosmsg2-serialization test