### PR TITLE
Ignore CDR final padding in trailing byte checks

### DIFF
--- a/packages/rosmsg2-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.test.ts
@@ -605,6 +605,18 @@ module builtin_interfaces {
     const threeZeroLengthArrays = [
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     ];
+    const finalPaddingDef = `
+      string frame_id
+      float64[9] position_covariance
+      uint8 position_covariance_type
+    `;
+
+    function makeFinalPaddingBuffer(): Uint8Array {
+      const buffer = new Uint8Array(96);
+      buffer.set(cdrHeader, 0);
+      buffer.set(serializeString("123456789"), 4);
+      return buffer;
+    }
 
     it("reports zero trailing bytes for an exact-fit decode", () => {
       const buffer = Uint8Array.from([...cdrHeader, ...threeZeroLengthArrays]);
@@ -632,6 +644,33 @@ module builtin_interfaces {
         texts: new Uint32Array(),
       });
       expect(reader.lastReadByteLength()).toBe(buffer.byteLength - trailing.length);
+      expect(reader.lastReadHadTrailingBytes()).toBe(true);
+    });
+
+    it("does not flag all-zero CDR final padding", () => {
+      const buffer = makeFinalPaddingBuffer();
+      const reader = new MessageReader(parseMessageDefinition(finalPaddingDef, { ros2: true }));
+
+      expect(reader.readMessage(buffer)).toEqual({
+        frame_id: "123456789",
+        position_covariance: new Float64Array(9),
+        position_covariance_type: 0,
+      });
+      expect(reader.lastReadByteLength()).toBe(93);
+      expect(reader.lastReadHadTrailingBytes()).toBe(false);
+    });
+
+    it("flags non-zero bytes in the final padding region", () => {
+      const buffer = makeFinalPaddingBuffer();
+      buffer[buffer.byteLength - 1] = 1;
+      const reader = new MessageReader(parseMessageDefinition(finalPaddingDef, { ros2: true }));
+
+      expect(reader.readMessage(buffer)).toEqual({
+        frame_id: "123456789",
+        position_covariance: new Float64Array(9),
+        position_covariance_type: 0,
+      });
+      expect(reader.lastReadByteLength()).toBe(93);
       expect(reader.lastReadHadTrailingBytes()).toBe(true);
     });
 

--- a/packages/rosmsg2-serialization/src/MessageReader.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.ts
@@ -48,8 +48,9 @@ export class MessageReader<T = unknown> {
   #useRos1Time: boolean;
 
   /**
-   * True when the most recent decode finished before reaching the end of the buffer. CDR ignores
-   * trailing bytes by design, so this can signal a schema/payload version mismatch.
+   * True when the most recent decode finished before reaching the end of the buffer, excluding CDR
+   * final padding. CDR ignores trailing bytes by design, so this can signal a schema/payload
+   * version mismatch.
    */
   public lastReadHadTrailingBytes(): boolean {
     return this.#lastReadHadTrailingBytes;
@@ -85,7 +86,9 @@ export class MessageReader<T = unknown> {
     const reader = new CdrReader(buffer);
     const value = this.#readComplexType(this.#rootDefinition, reader) as R;
     this.#lastReadByteLength = reader.decodedBytes;
-    this.#lastReadHadTrailingBytes = this.#lastReadByteLength < buffer.byteLength;
+    this.#lastReadHadTrailingBytes =
+      this.#lastReadByteLength < buffer.byteLength &&
+      !isCdrFinalPadding(buffer, this.#lastReadByteLength);
     return value;
   }
 
@@ -155,6 +158,29 @@ export class MessageReader<T = unknown> {
 function isConstantModule(def: MessageDefinition): boolean {
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   return def.definitions.length > 0 && def.definitions.every((field) => field.isConstant);
+}
+
+function isCdrFinalPadding(buffer: ArrayBufferView, decodedBytes: number): boolean {
+  const trailingByteLength = buffer.byteLength - decodedBytes;
+  if (trailingByteLength <= 0) {
+    return false;
+  }
+
+  const paddingToFourByteBoundary = (4 - (decodedBytes % 4)) % 4;
+  const paddingToEightByteBoundary = (8 - (decodedBytes % 8)) % 8;
+  if (
+    trailingByteLength !== paddingToFourByteBoundary &&
+    trailingByteLength !== paddingToEightByteBoundary
+  ) {
+    return false;
+  }
+
+  const trailingBytes = new Uint8Array(
+    buffer.buffer,
+    buffer.byteOffset + decodedBytes,
+    trailingByteLength,
+  );
+  return trailingBytes.every((byte) => byte === 0);
 }
 
 const deserializers = new Map<string, Deserializer>([

--- a/packages/rosmsg2-serialization/src/MessageReader.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.ts
@@ -166,6 +166,10 @@ function isCdrFinalPadding(buffer: ArrayBufferView, decodedBytes: number): boole
     return false;
   }
 
+  // The 4-byte branch is load-bearing: standard CDR1 final padding aligns the data section to a
+  // 4-byte boundary, and since the encapsulation header is itself 4 bytes, buffer-relative and
+  // data-relative alignment agree. The 8-byte branch is a buffer-relative best-effort for
+  // publishers that pad to a wider boundary.
   const paddingToFourByteBoundary = (4 - (decodedBytes % 4)) % 4;
   const paddingToEightByteBoundary = (8 - (decodedBytes % 8)) % 8;
   if (


### PR DESCRIPTION
### Changelog

Fixed false positive trailing-byte detection for ROS 2 CDR messages that end with alignment padding.

### Docs

None

### Description

`MessageReader.lastReadHadTrailingBytes()` is intended to identify cases where a ROS 2 message decodes successfully but the embedded schema did not account for the full serialized payload. That signal is useful for detecting schema skew, such as an older schema decoding only the prefix of a newer message.

The check was too literal for CDR payloads. It compared the decoded byte count with the full buffer length, so messages with valid all-zero final CDR alignment padding were reported as having trailing bytes. Common messages such as `sensor_msgs/msg/NavSatFix` can hit this when the decoded payload ends before the serialized sample boundary and the remaining bytes are only padding.

This PR keeps the public API unchanged. `lastReadByteLength()` still reports the literal decoded byte count, while `lastReadHadTrailingBytes()` now returns `false` when the only unread bytes are all-zero CDR final padding aligned to a 4- or 8-byte boundary. Non-padding leftovers still return `true`, preserving the original schema-skew detection behavior.

### Testing

No additional human verification required; this changes ROS 2 deserializer bookkeeping and is covered by focused unit tests for padding-only and non-padding trailing bytes.

### Links

[ERT-2268](https://linear.app/foxglove/issue/ERT-2268/fix-ros-typescript-trailing-byte-detection-for-cdr-final-padding)
