### PR TITLE
Bump serialization package versions

### DIFF
--- a/packages/rosmsg-serialization/package.json
+++ b/packages/rosmsg-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg-serialization",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "ROS 1 message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [

--- a/packages/rosmsg2-serialization/package.json
+++ b/packages/rosmsg2-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg2-serialization",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "ROS 2 message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Changelog

Bumped @foxglove/rosmsg-serialization to 2.1.1 and @foxglove/rosmsg2-serialization to 3.1.1.

### Docs

None

### Description

Updates the release metadata for the ROS 1 and ROS 2 serialization packages ahead of the next package publication. This is a metadata-only version bump with no runtime or API behavior changes.

### Testing

- Confirm the versions in packages/rosmsg-serialization/package.json and packages/rosmsg2-serialization/package.json match the intended release versions.

### Links

None
