### PR TITLE
fix: port rosmsg-serialization UTF-8 string length logic to rosmsg2-serialization

### DIFF
--- a/packages/rosmsg2-serialization/src/MessageWriter.ts
+++ b/packages/rosmsg2-serialization/src/MessageWriter.ts
@@ -6,6 +6,7 @@ import {
 } from "@foxglove/message-definition";
 
 import { messageDefinitionHasDataFields } from "./messageDefinitionHasDataFields";
+import { stringLengthUtf8 } from "./stringLengthUtf8";
 
 type PrimitiveWriter = (
   value: unknown,
@@ -159,7 +160,7 @@ export class MessageWriter {
           for (let i = 0; i < arrayLength; i++) {
             const entry = (dataArray[i] ?? "") as string;
             newOffset += padding(newOffset, 4);
-            newOffset += 4 + entry.length + 1; // uint32 length prefix, string, null terminator
+            newOffset += 4 + stringLengthUtf8(entry) + 1; // uint32 length prefix, string, null terminator
           }
         } else {
           // Primitive array
@@ -178,7 +179,7 @@ export class MessageWriter {
           // String
           const entry = typeof nestedMessage === "string" ? nestedMessage : "";
           newOffset += padding(newOffset, 4);
-          newOffset += 4 + entry.length + 1; // uint32 length prefix, string, null terminator
+          newOffset += 4 + stringLengthUtf8(entry) + 1; // uint32 length prefix, string, null terminator
         } else {
           // Primitive
           const entrySize = this.#getPrimitiveSize(field.type);

--- a/packages/rosmsg2-serialization/src/stringLengthUtf8.test.ts
+++ b/packages/rosmsg2-serialization/src/stringLengthUtf8.test.ts
@@ -1,0 +1,36 @@
+import { stringLengthUtf8 } from "./stringLengthUtf8";
+
+describe("stringLengthUtf8", () => {
+  it.each([
+    "",
+    "a",
+    "ab",
+    "abc",
+    "abcd",
+    "béta",
+    "\xE9",
+    "\u0000",
+    "\u007f",
+    "\u0080",
+    "\u07ff",
+    "\u0800",
+    "\ud800", // lone high surrogate
+    "\ud800x", // lone high surrogate
+    "x\ud800", // lone high surrogate
+    "\ud800\udc00", // surrogate pair, equivalent to "𐀀" or "\u{10000}"
+    "\udbff\udfff", // surrogate pair, equivalent to "\u{10ffff}"
+    "\udc00", // lone low surrogate
+    "\udc00x", // lone low surrogate
+    "x\udc00", // lone low surrogate
+    "\u7fff",
+    "\u8000",
+    "\u8001",
+    "\uffff",
+    "\u{10000}",
+    "\u{fffff}",
+    "\u{100000}",
+    "\u{10ffff}",
+  ])("agrees with TextEncoder", (str) => {
+    expect(stringLengthUtf8(str)).toEqual(new TextEncoder().encode(str).length);
+  });
+});

--- a/packages/rosmsg2-serialization/src/stringLengthUtf8.ts
+++ b/packages/rosmsg2-serialization/src/stringLengthUtf8.ts
@@ -1,0 +1,32 @@
+/**
+ * Returns the number of bytes that would be used when encoding the string as UTF-8, effectively the
+ * same as `new TextEncoder().encode(str).length` but faster.
+ * https://jsbench.me/nzlrkwmeiq/1
+ */
+export function stringLengthUtf8(str: string): number {
+  let byteLength = 0;
+  const numCodeUnits = str.length;
+  for (let i = 0; i < numCodeUnits; i++) {
+    const codeUnit = str.charCodeAt(i); // 0x0000-0xFFFF
+    if (codeUnit <= 0x7f) {
+      byteLength += 1; // 0b0xxxxxxx
+    } else if (codeUnit <= 0x7ff) {
+      byteLength += 2; // 0b110xxxxx 0b10xxxxxx
+    } else if (0xd800 <= codeUnit && codeUnit <= 0xdbff) {
+      // If the input string is valid UTF-16 then these surrogate characters come in pairs. They
+      // represent code points in the range 0x100000-0x10ffff and are represented with 4 bytes in
+      // UTF-8.
+      const nextCodeUnit = str.charCodeAt(i + 1);
+      if (0xdc00 <= nextCodeUnit && nextCodeUnit <= 0xdfff) {
+        byteLength += 4; // 0b11110xxx 0b10xxxxxx 0b10xxxxxx 0b10xxxxxx
+        i++;
+      } else {
+        byteLength += 3; // 0b1110xxxx 0b10xxxxxx 0b10xxxxxx
+      }
+    } else {
+      // <= 0xFFFF
+      byteLength += 3; // 0b1110xxxx 0b10xxxxxx 0b10xxxxxx
+    }
+  }
+  return byteLength;
+}


### PR DESCRIPTION
When a string contains multi-byte characters (e.g., UTF-8 Chinese, Emojis), the ROS 1 message serialization package (`rosmsg-serialization`) handles it correctly. However, the ROS 2 message serialization package (`rosmsg2-serialization`) uses `String.length`, which is the character count rather than the byte length. This can lead to unexpected truncation when transferring string data using the ros2msg encoding scheme with CDR.

I have ported the logic from rosmsg-serialization to fix this issue.