### PR TITLE
Bump rosmsg2-serialization to 3.1.2

### DIFF
--- a/packages/rosmsg2-serialization/package.json
+++ b/packages/rosmsg2-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg2-serialization",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "ROS 2 message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Description

Bumps @foxglove/rosmsg2-serialization to 3.1.2 so the next package release includes the current main branch fixes, including the CDR 3.5.1 dependency update and UTF-8 string sizing fix.

This is release metadata only.

### Validation

- `yarn workspaces foreach -Rp --topological-dev --from @foxglove/rosmsg2-serialization run build`
- `yarn lint:ci packages/rosmsg2-serialization`
- `yarn workspace @foxglove/rosmsg2-serialization test`