### PR TITLE
fix(rosmsg-serialization): reject invalid field names before codegen

### DIFF
--- a/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
@@ -6,7 +6,7 @@ import { LazyMessageReader } from "./LazyMessageReader";
 import messageReaderTests from "./fixtures/messageReaderTests";
 
 describe("LazyReader", () => {
-  it("rejects unsafe field names before generating lazy readers", () => {
+  it("rejects invalid ROS field names before generating lazy readers", () => {
     const globalWithMarker = globalThis as typeof globalThis & {
       rosmsgSerializationLazyReaderInjected?: boolean;
     };
@@ -26,9 +26,7 @@ describe("LazyReader", () => {
       },
     ];
 
-    expect(() => new LazyMessageReader(definitions)).toThrow(
-      /Invalid message definition field name/,
-    );
+    expect(() => new LazyMessageReader(definitions)).toThrow(/valid ROS field name/);
     expect(globalWithMarker.rosmsgSerializationLazyReaderInjected).toBeUndefined();
   });
 

--- a/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
@@ -1,3 +1,4 @@
+import type { MessageDefinition } from "@foxglove/message-definition";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import * as prettier from "prettier";
 
@@ -5,6 +6,34 @@ import { LazyMessageReader } from "./LazyMessageReader";
 import messageReaderTests from "./fixtures/messageReaderTests";
 
 describe("LazyReader", () => {
+  it("treats field names as data when generating lazy readers", () => {
+    const globalWithMarker = globalThis as typeof globalThis & {
+      __rosmsgSerializationLazyReaderInjected?: boolean;
+    };
+    delete globalWithMarker.__rosmsgSerializationLazyReaderInjected;
+    const payloadName = "x; globalThis.__rosmsgSerializationLazyReaderInjected = true; this.y";
+    const definitions: MessageDefinition[] = [
+      {
+        definitions: [
+          {
+            name: payloadName,
+            type: "string",
+            isArray: false,
+            isComplex: false,
+            isConstant: false,
+          },
+        ],
+      },
+    ];
+    const reader = new LazyMessageReader<Record<string, string>>(definitions);
+
+    const read = reader.readMessage(Buffer.alloc(4));
+
+    expect(read[payloadName]).toEqual("");
+    expect(read.toObject()).toEqual({ [payloadName]: "" });
+    expect(globalWithMarker.__rosmsgSerializationLazyReaderInjected).toBeUndefined();
+  });
+
   it.each(messageReaderTests)(
     "should deserialize %s",
     async (msgDef: string, arr: Iterable<number>, expected: Record<string, unknown>) => {

--- a/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
@@ -8,10 +8,10 @@ import messageReaderTests from "./fixtures/messageReaderTests";
 describe("LazyReader", () => {
   it("treats field names as data when generating lazy readers", () => {
     const globalWithMarker = globalThis as typeof globalThis & {
-      __rosmsgSerializationLazyReaderInjected?: boolean;
+      rosmsgSerializationLazyReaderInjected?: boolean;
     };
-    delete globalWithMarker.__rosmsgSerializationLazyReaderInjected;
-    const payloadName = "x; globalThis.__rosmsgSerializationLazyReaderInjected = true; this.y";
+    delete globalWithMarker.rosmsgSerializationLazyReaderInjected;
+    const payloadName = "x; globalThis.rosmsgSerializationLazyReaderInjected = true; this.y";
     const definitions: MessageDefinition[] = [
       {
         definitions: [
@@ -31,7 +31,7 @@ describe("LazyReader", () => {
 
     expect(read[payloadName]).toEqual("");
     expect(read.toObject()).toEqual({ [payloadName]: "" });
-    expect(globalWithMarker.__rosmsgSerializationLazyReaderInjected).toBeUndefined();
+    expect(globalWithMarker.rosmsgSerializationLazyReaderInjected).toBeUndefined();
   });
 
   it.each(messageReaderTests)(

--- a/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
@@ -6,7 +6,7 @@ import { LazyMessageReader } from "./LazyMessageReader";
 import messageReaderTests from "./fixtures/messageReaderTests";
 
 describe("LazyReader", () => {
-  it("treats field names as data when generating lazy readers", () => {
+  it("rejects unsafe field names before generating lazy readers", () => {
     const globalWithMarker = globalThis as typeof globalThis & {
       rosmsgSerializationLazyReaderInjected?: boolean;
     };
@@ -25,12 +25,10 @@ describe("LazyReader", () => {
         ],
       },
     ];
-    const reader = new LazyMessageReader<Record<string, string>>(definitions);
 
-    const read = reader.readMessage(Buffer.alloc(4));
-
-    expect(read[payloadName]).toEqual("");
-    expect(read.toObject()).toEqual({ [payloadName]: "" });
+    expect(() => new LazyMessageReader(definitions)).toThrow(
+      /Invalid message definition field name/,
+    );
     expect(globalWithMarker.rosmsgSerializationLazyReaderInjected).toBeUndefined();
   });
 

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -23,10 +23,10 @@ const getStringBuffer = (str: string) => {
 describe("MessageReader", () => {
   it("treats field names as data when generating readers", () => {
     const globalWithMarker = globalThis as typeof globalThis & {
-      __rosmsgSerializationReaderInjected?: boolean;
+      rosmsgSerializationReaderInjected?: boolean;
     };
-    delete globalWithMarker.__rosmsgSerializationReaderInjected;
-    const payloadName = "x; globalThis.__rosmsgSerializationReaderInjected = true; this.y";
+    delete globalWithMarker.rosmsgSerializationReaderInjected;
+    const payloadName = "x; globalThis.rosmsgSerializationReaderInjected = true; this.y";
     const definitions: MessageDefinition[] = [
       {
         name: "std_msgs/String",
@@ -45,7 +45,7 @@ describe("MessageReader", () => {
     const reader = new MessageReader(definitions);
 
     expect(reader.readMessage(Buffer.alloc(4))).toEqual({ [payloadName]: "" });
-    expect(globalWithMarker.__rosmsgSerializationReaderInjected).toBeUndefined();
+    expect(globalWithMarker.rosmsgSerializationReaderInjected).toBeUndefined();
   });
 
   it.each(messageReaderTests)(

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -7,6 +7,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import type { MessageDefinition } from "@foxglove/message-definition";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 
 import { MessageReader } from "./MessageReader";
@@ -20,6 +21,33 @@ const getStringBuffer = (str: string) => {
 };
 
 describe("MessageReader", () => {
+  it("treats field names as data when generating readers", () => {
+    const globalWithMarker = globalThis as typeof globalThis & {
+      __rosmsgSerializationReaderInjected?: boolean;
+    };
+    delete globalWithMarker.__rosmsgSerializationReaderInjected;
+    const payloadName = "x; globalThis.__rosmsgSerializationReaderInjected = true; this.y";
+    const definitions: MessageDefinition[] = [
+      {
+        name: "std_msgs/String",
+        definitions: [
+          {
+            name: payloadName,
+            type: "string",
+            isArray: false,
+            isComplex: false,
+            isConstant: false,
+          },
+        ],
+      },
+    ];
+
+    const reader = new MessageReader(definitions);
+
+    expect(reader.readMessage(Buffer.alloc(4))).toEqual({ [payloadName]: "" });
+    expect(globalWithMarker.__rosmsgSerializationReaderInjected).toBeUndefined();
+  });
+
   it.each(messageReaderTests)(
     "should deserialize %s",
     (msgDef: string, arr: Iterable<number>, expected: Record<string, unknown>) => {

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -46,6 +46,12 @@ describe("MessageReader", () => {
     expect(globalWithMarker.rosmsgSerializationReaderInjected).toBeUndefined();
   });
 
+  it("allows reserved words as field names", () => {
+    const reader = new MessageReader(parseMessageDefinition("uint8 function"));
+
+    expect(reader.readMessage(Uint8Array.from([3]))).toEqual({ function: 3 });
+  });
+
   it.each(messageReaderTests)(
     "should deserialize %s",
     (msgDef: string, arr: Iterable<number>, expected: Record<string, unknown>) => {

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -21,7 +21,7 @@ const getStringBuffer = (str: string) => {
 };
 
 describe("MessageReader", () => {
-  it("treats field names as data when generating readers", () => {
+  it("rejects unsafe field names before generating readers", () => {
     const globalWithMarker = globalThis as typeof globalThis & {
       rosmsgSerializationReaderInjected?: boolean;
     };
@@ -42,9 +42,7 @@ describe("MessageReader", () => {
       },
     ];
 
-    const reader = new MessageReader(definitions);
-
-    expect(reader.readMessage(Buffer.alloc(4))).toEqual({ [payloadName]: "" });
+    expect(() => new MessageReader(definitions)).toThrow(/Invalid message definition field name/);
     expect(globalWithMarker.rosmsgSerializationReaderInjected).toBeUndefined();
   });
 

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -21,7 +21,7 @@ const getStringBuffer = (str: string) => {
 };
 
 describe("MessageReader", () => {
-  it("rejects unsafe field names before generating readers", () => {
+  it("rejects invalid ROS field names before generating readers", () => {
     const globalWithMarker = globalThis as typeof globalThis & {
       rosmsgSerializationReaderInjected?: boolean;
     };
@@ -42,7 +42,7 @@ describe("MessageReader", () => {
       },
     ];
 
-    expect(() => new MessageReader(definitions)).toThrow(/Invalid message definition field name/);
+    expect(() => new MessageReader(definitions)).toThrow(/valid ROS field name/);
     expect(globalWithMarker.rosmsgSerializationReaderInjected).toBeUndefined();
   });
 

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -189,9 +189,22 @@ const findTypeByName = (types: readonly MessageDefinition[], name = ""): NamedMe
   return { ...matches[0]!, name: foundName };
 };
 
-const friendlyName = (name: string) => name.replace(/\//g, "_");
-
 type NamedMessageDefinition = MessageDefinition & { name: string };
+
+function sourceString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function arrayLengthSource(def: MessageDefinitionField): string {
+  const { arrayLength } = def;
+  if (arrayLength == undefined) {
+    return "undefined";
+  }
+  if (!Number.isSafeInteger(arrayLength) || arrayLength < 0) {
+    throw new Error(`Invalid array length ${String(arrayLength)} for field '${def.name}'`);
+  }
+  return String(arrayLength);
+}
 
 function toTypedArrayType(rosType: string): string | undefined {
   switch (rosType) {
@@ -247,47 +260,54 @@ export const createParsers = ({
 
   const constructorBody = (type: MessageDefinition | NamedMessageDefinition) => {
     const readerLines: string[] = [];
-    type.definitions.forEach((def) => {
+    type.definitions.forEach((def, index) => {
       if (def.isConstant === true) {
         return;
       }
+      const fieldName = sourceString(def.name);
+      const setField = (value: string) => `setField(this, ${fieldName}, ${value});`;
       if (def.isArray === true) {
         // detect if typed array
         const typedArrayType = toTypedArrayType(def.type);
         if (typedArrayType != undefined) {
           readerLines.push(
-            `this.${def.name} = reader.typedArray(${String(def.arrayLength)}, ${typedArrayType});`,
+            setField(`reader.typedArray(${arrayLengthSource(def)}, ${typedArrayType})`),
           );
           return;
         }
 
-        const lenField = `length_${def.name}`;
+        const lenField = `length_${index}`;
         // set a variable pointing to the parsed fixed array length
         // or read the byte indicating the dynamic length
-        readerLines.push(`var ${lenField} = ${def.arrayLength ?? "reader.uint32();"}`);
+        readerLines.push(
+          `var ${lenField} = ${def.arrayLength == undefined ? "reader.uint32()" : arrayLengthSource(def)};`,
+        );
 
         // only allocate an array if there is a length - skips empty allocations
-        const arrayName = `this.${def.name}`;
+        const arrayName = `array_${index}`;
 
         // allocate the new array to a fixed length since we know it ahead of time
-        readerLines.push(`${arrayName} = new Array(${lenField})`);
+        readerLines.push(`var ${arrayName} = new Array(${lenField});`);
+        readerLines.push(setField(arrayName));
         // start the for-loop
         readerLines.push(`for (var i = 0; i < ${lenField}; i++) {`);
         // if the sub type is complex we need to allocate it and parse its values
         if (def.isComplex === true) {
           const defType = findTypeByName(definitions, def.type);
           // recursively call the constructor for the sub-type
-          readerLines.push(`  ${arrayName}[i] = new Record.${friendlyName(defType.name)}(reader);`);
+          readerLines.push(
+            `  ${arrayName}[i] = new (Record[${sourceString(defType.name)}])(reader);`,
+          );
         } else {
           // if the subtype is not complex its a simple low-level reader operation
-          readerLines.push(`  ${arrayName}[i] = reader.${def.type}();`);
+          readerLines.push(`  ${arrayName}[i] = reader[${sourceString(def.type)}]();`);
         }
         readerLines.push("}"); // close the for-loop
       } else if (def.isComplex === true) {
         const defType = findTypeByName(definitions, def.type);
-        readerLines.push(`this.${def.name} = new Record.${friendlyName(defType.name)}(reader);`);
+        readerLines.push(setField(`new (Record[${sourceString(defType.name)}])(reader)`));
       } else {
-        readerLines.push(`this.${def.name} = reader.${def.type}();`);
+        readerLines.push(setField(`reader[${sourceString(def.type)}]()`));
       }
     });
     if (options.freeze === true) {
@@ -298,6 +318,14 @@ export const createParsers = ({
 
   let js = `
   const builtReaders = new Map();
+  function setField(record, name, value) {
+    Object.defineProperty(record, name, {
+      value,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
   var Record = function (reader) {
     ${constructorBody(unnamedType)}
   };
@@ -306,10 +334,10 @@ export const createParsers = ({
 
   for (const type of namedTypes) {
     js += `
-  Record.${friendlyName(type.name)} = function(reader) {
+  setField(Record, ${sourceString(type.name)}, function(reader) {
     ${constructorBody(type)}
-  };
-  builtReaders.set(${JSON.stringify(type.name)}, Record.${friendlyName(type.name)});
+  });
+  builtReaders.set(${sourceString(type.name)}, Record[${sourceString(type.name)}]);
   `;
   }
 

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -7,7 +7,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { MessageDefinition } from "@foxglove/message-definition";
+import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
 
 import decodeString from "./decodeString";
 

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -7,9 +7,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
+import { MessageDefinition } from "@foxglove/message-definition";
 
 import decodeString from "./decodeString";
+import { validateMessageDefinitionsForCodegen } from "./validateMessageDefinitions";
 
 type TypedArray =
   | Int8Array
@@ -189,22 +190,9 @@ const findTypeByName = (types: readonly MessageDefinition[], name = ""): NamedMe
   return { ...matches[0]!, name: foundName };
 };
 
+const friendlyName = (name: string) => name.replace(/\//g, "_");
+
 type NamedMessageDefinition = MessageDefinition & { name: string };
-
-function sourceString(value: string): string {
-  return JSON.stringify(value);
-}
-
-function arrayLengthSource(def: MessageDefinitionField): string {
-  const { arrayLength } = def;
-  if (arrayLength == undefined) {
-    return "undefined";
-  }
-  if (!Number.isSafeInteger(arrayLength) || arrayLength < 0) {
-    throw new Error(`Invalid array length ${String(arrayLength)} for field '${def.name}'`);
-  }
-  return String(arrayLength);
-}
 
 function toTypedArrayType(rosType: string): string | undefined {
   switch (rosType) {
@@ -245,6 +233,7 @@ export const createParsers = ({
   if (definitions.length === 0) {
     throw new Error(`no types given`);
   }
+  validateMessageDefinitionsForCodegen(definitions, { validateTypeNames: true });
 
   const unnamedTypes = definitions.filter((type) => !type.name);
   if (unnamedTypes.length > 1) {
@@ -260,54 +249,47 @@ export const createParsers = ({
 
   const constructorBody = (type: MessageDefinition | NamedMessageDefinition) => {
     const readerLines: string[] = [];
-    type.definitions.forEach((def, index) => {
+    type.definitions.forEach((def) => {
       if (def.isConstant === true) {
         return;
       }
-      const fieldName = sourceString(def.name);
-      const setField = (value: string) => `setField(this, ${fieldName}, ${value});`;
       if (def.isArray === true) {
         // detect if typed array
         const typedArrayType = toTypedArrayType(def.type);
         if (typedArrayType != undefined) {
           readerLines.push(
-            setField(`reader.typedArray(${arrayLengthSource(def)}, ${typedArrayType})`),
+            `this.${def.name} = reader.typedArray(${String(def.arrayLength)}, ${typedArrayType});`,
           );
           return;
         }
 
-        const lenField = `length_${index}`;
+        const lenField = `length_${def.name}`;
         // set a variable pointing to the parsed fixed array length
         // or read the byte indicating the dynamic length
-        readerLines.push(
-          `var ${lenField} = ${def.arrayLength == undefined ? "reader.uint32()" : arrayLengthSource(def)};`,
-        );
+        readerLines.push(`var ${lenField} = ${def.arrayLength ?? "reader.uint32();"}`);
 
         // only allocate an array if there is a length - skips empty allocations
-        const arrayName = `array_${index}`;
+        const arrayName = `this.${def.name}`;
 
         // allocate the new array to a fixed length since we know it ahead of time
-        readerLines.push(`var ${arrayName} = new Array(${lenField});`);
-        readerLines.push(setField(arrayName));
+        readerLines.push(`${arrayName} = new Array(${lenField})`);
         // start the for-loop
         readerLines.push(`for (var i = 0; i < ${lenField}; i++) {`);
         // if the sub type is complex we need to allocate it and parse its values
         if (def.isComplex === true) {
           const defType = findTypeByName(definitions, def.type);
           // recursively call the constructor for the sub-type
-          readerLines.push(
-            `  ${arrayName}[i] = new (Record[${sourceString(defType.name)}])(reader);`,
-          );
+          readerLines.push(`  ${arrayName}[i] = new Record.${friendlyName(defType.name)}(reader);`);
         } else {
           // if the subtype is not complex its a simple low-level reader operation
-          readerLines.push(`  ${arrayName}[i] = reader[${sourceString(def.type)}]();`);
+          readerLines.push(`  ${arrayName}[i] = reader.${def.type}();`);
         }
         readerLines.push("}"); // close the for-loop
       } else if (def.isComplex === true) {
         const defType = findTypeByName(definitions, def.type);
-        readerLines.push(setField(`new (Record[${sourceString(defType.name)}])(reader)`));
+        readerLines.push(`this.${def.name} = new Record.${friendlyName(defType.name)}(reader);`);
       } else {
-        readerLines.push(setField(`reader[${sourceString(def.type)}]()`));
+        readerLines.push(`this.${def.name} = reader.${def.type}();`);
       }
     });
     if (options.freeze === true) {
@@ -318,14 +300,6 @@ export const createParsers = ({
 
   let js = `
   const builtReaders = new Map();
-  function setField(record, name, value) {
-    Object.defineProperty(record, name, {
-      value,
-      enumerable: true,
-      writable: true,
-      configurable: true,
-    });
-  }
   var Record = function (reader) {
     ${constructorBody(unnamedType)}
   };
@@ -334,10 +308,10 @@ export const createParsers = ({
 
   for (const type of namedTypes) {
     js += `
-  setField(Record, ${sourceString(type.name)}, function(reader) {
+  Record.${friendlyName(type.name)} = function(reader) {
     ${constructorBody(type)}
-  });
-  builtReaders.set(${sourceString(type.name)}, Record[${sourceString(type.name)}]);
+  };
+  builtReaders.set(${JSON.stringify(type.name)}, Record.${friendlyName(type.name)});
   `;
   }
 

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -233,7 +233,7 @@ export const createParsers = ({
   if (definitions.length === 0) {
     throw new Error(`no types given`);
   }
-  validateMessageDefinitionsForCodegen(definitions, { validateTypeNames: true });
+  validateMessageDefinitionsForCodegen(definitions);
 
   const unnamedTypes = definitions.filter((type) => !type.name);
   if (unnamedTypes.length > 1) {

--- a/packages/rosmsg-serialization/src/MessageWriter.test.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.test.ts
@@ -61,7 +61,7 @@ function writeDoubleLE(data: Uint8Array, value: number, offset: number): void {
 }
 
 describe("MessageWriter", () => {
-  it("rejects unsafe field names before generating writers", () => {
+  it("rejects invalid ROS field names before generating writers", () => {
     const globalWithMarker = globalThis as typeof globalThis & {
       rosmsgSerializationWriterInjected?: boolean;
     };
@@ -81,7 +81,7 @@ describe("MessageWriter", () => {
       },
     ];
 
-    expect(() => new MessageWriter(definitions)).toThrow(/Invalid message definition field name/);
+    expect(() => new MessageWriter(definitions)).toThrow(/valid ROS field name/);
     expect(globalWithMarker.rosmsgSerializationWriterInjected).toBeUndefined();
   });
 

--- a/packages/rosmsg-serialization/src/MessageWriter.test.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.test.ts
@@ -63,10 +63,10 @@ function writeDoubleLE(data: Uint8Array, value: number, offset: number): void {
 describe("MessageWriter", () => {
   it("treats field names as data when generating writers", () => {
     const globalWithMarker = globalThis as typeof globalThis & {
-      __rosmsgSerializationWriterInjected?: boolean;
+      rosmsgSerializationWriterInjected?: boolean;
     };
-    delete globalWithMarker.__rosmsgSerializationWriterInjected;
-    const payloadName = 'x"]; globalThis.__rosmsgSerializationWriterInjected = true; message["y';
+    delete globalWithMarker.rosmsgSerializationWriterInjected;
+    const payloadName = 'x"]; globalThis.rosmsgSerializationWriterInjected = true; message["y';
     const definitions: MessageDefinition[] = [
       {
         definitions: [
@@ -83,7 +83,7 @@ describe("MessageWriter", () => {
     const writer = new MessageWriter(definitions);
 
     expect(writer.writeMessage({ [payloadName]: "" })).toEqual(Buffer.alloc(4));
-    expect(globalWithMarker.__rosmsgSerializationWriterInjected).toBeUndefined();
+    expect(globalWithMarker.rosmsgSerializationWriterInjected).toBeUndefined();
   });
 
   describe("simple type", () => {

--- a/packages/rosmsg-serialization/src/MessageWriter.test.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.test.ts
@@ -7,6 +7,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import type { MessageDefinition } from "@foxglove/message-definition";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 
 import { MessageReader } from "./MessageReader";
@@ -60,6 +61,31 @@ function writeDoubleLE(data: Uint8Array, value: number, offset: number): void {
 }
 
 describe("MessageWriter", () => {
+  it("treats field names as data when generating writers", () => {
+    const globalWithMarker = globalThis as typeof globalThis & {
+      __rosmsgSerializationWriterInjected?: boolean;
+    };
+    delete globalWithMarker.__rosmsgSerializationWriterInjected;
+    const payloadName = 'x"]; globalThis.__rosmsgSerializationWriterInjected = true; message["y';
+    const definitions: MessageDefinition[] = [
+      {
+        definitions: [
+          {
+            name: payloadName,
+            type: "string",
+            isArray: false,
+            isComplex: false,
+            isConstant: false,
+          },
+        ],
+      },
+    ];
+    const writer = new MessageWriter(definitions);
+
+    expect(writer.writeMessage({ [payloadName]: "" })).toEqual(Buffer.alloc(4));
+    expect(globalWithMarker.__rosmsgSerializationWriterInjected).toBeUndefined();
+  });
+
   describe("simple type", () => {
     const testNum = (
       type: string,

--- a/packages/rosmsg-serialization/src/MessageWriter.test.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.test.ts
@@ -61,7 +61,7 @@ function writeDoubleLE(data: Uint8Array, value: number, offset: number): void {
 }
 
 describe("MessageWriter", () => {
-  it("treats field names as data when generating writers", () => {
+  it("rejects unsafe field names before generating writers", () => {
     const globalWithMarker = globalThis as typeof globalThis & {
       rosmsgSerializationWriterInjected?: boolean;
     };
@@ -80,9 +80,8 @@ describe("MessageWriter", () => {
         ],
       },
     ];
-    const writer = new MessageWriter(definitions);
 
-    expect(writer.writeMessage({ [payloadName]: "" })).toEqual(Buffer.alloc(4));
+    expect(() => new MessageWriter(definitions)).toThrow(/Invalid message definition field name/);
     expect(globalWithMarker.rosmsgSerializationWriterInjected).toBeUndefined();
   });
 

--- a/packages/rosmsg-serialization/src/MessageWriter.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.ts
@@ -10,6 +10,7 @@
 import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
 
 import { stringLengthUtf8 } from "./stringLengthUtf8";
+import { validateMessageDefinitionsForCodegen } from "./validateMessageDefinitions";
 
 export interface Time {
   // whole seconds
@@ -223,21 +224,7 @@ const findTypeByName = (types: MessageDefinition[], name = ""): NamedRosMsgDefin
   return { ...matches[0]!, name: foundName };
 };
 
-function sourceString(value: string): string {
-  return JSON.stringify(value);
-}
-
-function arrayLengthSource(def: MessageDefinitionField): string {
-  const { arrayLength } = def;
-  if (arrayLength == undefined) {
-    return "undefined";
-  }
-  if (!Number.isSafeInteger(arrayLength) || arrayLength < 0) {
-    throw new Error(`Invalid array length ${String(arrayLength)} for field '${def.name}'`);
-  }
-  return String(arrayLength);
-}
-
+const friendlyName = (name: string): string => name.replace(/\//g, "_");
 type WriterAndSizeCalculator = {
   writer: (message: unknown, output: Uint8Array) => Uint8Array;
   byteSizeCalculator: (message: unknown) => number;
@@ -247,6 +234,7 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
   if (types.length === 0) {
     throw new Error(`no types given`);
   }
+  validateMessageDefinitionsForCodegen(types, { validateTypeNames: true });
 
   const unnamedTypes = types.filter((type) => type.name == undefined);
   if (unnamedTypes.length > 1) {
@@ -259,29 +247,24 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
     (type) => type.name != undefined,
   ) as NamedRosMsgDefinition[];
 
-  const functionNamesByType = new Map<string, string>();
-  namedTypes.forEach((type, index) => {
-    functionNamesByType.set(type.name, `type_${index}`);
-  });
-
   const constructorBody = (
     type: MessageDefinition | NamedRosMsgDefinition,
     argName: "offsetCalculator" | "writer",
   ): string => {
     const lines: string[] = [];
-    type.definitions.forEach((def, index) => {
+    type.definitions.forEach((def) => {
       if (def.isConstant ?? false) {
         return;
       }
 
       // Accesses the field we are currently writing. Pulled out for easy reuse.
-      const accessMessageField = `message[${sourceString(def.name)}]`;
+      const accessMessageField = `message["${def.name}"]`;
       if (def.isArray ?? false) {
-        const lenField = `length_${index}`;
+        const lenField = `length_${def.name}`;
         // set a variable pointing to the parsed fixed array length
         // or write the byte indicating the dynamic length
         if (def.arrayLength != undefined) {
-          lines.push(`var ${lenField} = ${arrayLengthSource(def)};`);
+          lines.push(`var ${lenField} = ${def.arrayLength};`);
         } else {
           lines.push(`var ${lenField} = ${accessMessageField}.length;`);
           lines.push(`${argName}.uint32(${lenField});`);
@@ -292,27 +275,19 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
         // if the sub type is complex we need to allocate it and parse its values
         if (def.isComplex ?? false) {
           const defType = findTypeByName(types, def.type);
-          const functionName = functionNamesByType.get(defType.name);
-          if (functionName == undefined) {
-            throw new Error(`No writer function for type '${defType.name}'`);
-          }
           // recursively call the function for the sub-type
-          lines.push(`  ${functionName}(${argName}, ${accessMessageField}[i]);`);
+          lines.push(`  ${friendlyName(defType.name)}(${argName}, ${accessMessageField}[i]);`);
         } else {
           // if the subtype is not complex its a simple low-level operation
-          lines.push(`  ${argName}[${sourceString(def.type)}](${accessMessageField}[i]);`);
+          lines.push(`  ${argName}.${def.type}(${accessMessageField}[i]);`);
         }
         lines.push("}"); // close the for-loop
       } else if (def.isComplex ?? false) {
         const defType = findTypeByName(types, def.type);
-        const functionName = functionNamesByType.get(defType.name);
-        if (functionName == undefined) {
-          throw new Error(`No writer function for type '${defType.name}'`);
-        }
-        lines.push(`${functionName}(${argName}, ${accessMessageField});`);
+        lines.push(`${friendlyName(defType.name)}(${argName}, ${accessMessageField});`);
       } else {
         // Call primitives directly.
-        lines.push(`${argName}[${sourceString(def.type)}](${accessMessageField});`);
+        lines.push(`${argName}.${def.type}(${accessMessageField});`);
       }
     });
     return lines.join("\n    ");
@@ -322,13 +297,12 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
   let calculateSizeJs = "";
 
   namedTypes.forEach((t) => {
-    const functionName = functionNamesByType.get(t.name)!;
     writerJs += `
-  function ${functionName}(writer, message) {
+  function ${friendlyName(t.name)}(writer, message) {
     ${constructorBody(t, "writer")}
   };\n`;
     calculateSizeJs += `
-  function ${functionName}(offsetCalculator, message) {
+  function ${friendlyName(t.name)}(offsetCalculator, message) {
     ${constructorBody(t, "offsetCalculator")}
   };\n`;
   });

--- a/packages/rosmsg-serialization/src/MessageWriter.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.ts
@@ -223,7 +223,21 @@ const findTypeByName = (types: MessageDefinition[], name = ""): NamedRosMsgDefin
   return { ...matches[0]!, name: foundName };
 };
 
-const friendlyName = (name: string): string => name.replace(/\//g, "_");
+function sourceString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function arrayLengthSource(def: MessageDefinitionField): string {
+  const { arrayLength } = def;
+  if (arrayLength == undefined) {
+    return "undefined";
+  }
+  if (!Number.isSafeInteger(arrayLength) || arrayLength < 0) {
+    throw new Error(`Invalid array length ${String(arrayLength)} for field '${def.name}'`);
+  }
+  return String(arrayLength);
+}
+
 type WriterAndSizeCalculator = {
   writer: (message: unknown, output: Uint8Array) => Uint8Array;
   byteSizeCalculator: (message: unknown) => number;
@@ -245,24 +259,29 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
     (type) => type.name != undefined,
   ) as NamedRosMsgDefinition[];
 
+  const functionNamesByType = new Map<string, string>();
+  namedTypes.forEach((type, index) => {
+    functionNamesByType.set(type.name, `type_${index}`);
+  });
+
   const constructorBody = (
     type: MessageDefinition | NamedRosMsgDefinition,
     argName: "offsetCalculator" | "writer",
   ): string => {
     const lines: string[] = [];
-    type.definitions.forEach((def) => {
+    type.definitions.forEach((def, index) => {
       if (def.isConstant ?? false) {
         return;
       }
 
       // Accesses the field we are currently writing. Pulled out for easy reuse.
-      const accessMessageField = `message["${def.name}"]`;
+      const accessMessageField = `message[${sourceString(def.name)}]`;
       if (def.isArray ?? false) {
-        const lenField = `length_${def.name}`;
+        const lenField = `length_${index}`;
         // set a variable pointing to the parsed fixed array length
         // or write the byte indicating the dynamic length
         if (def.arrayLength != undefined) {
-          lines.push(`var ${lenField} = ${def.arrayLength};`);
+          lines.push(`var ${lenField} = ${arrayLengthSource(def)};`);
         } else {
           lines.push(`var ${lenField} = ${accessMessageField}.length;`);
           lines.push(`${argName}.uint32(${lenField});`);
@@ -273,19 +292,27 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
         // if the sub type is complex we need to allocate it and parse its values
         if (def.isComplex ?? false) {
           const defType = findTypeByName(types, def.type);
+          const functionName = functionNamesByType.get(defType.name);
+          if (functionName == undefined) {
+            throw new Error(`No writer function for type '${defType.name}'`);
+          }
           // recursively call the function for the sub-type
-          lines.push(`  ${friendlyName(defType.name)}(${argName}, ${accessMessageField}[i]);`);
+          lines.push(`  ${functionName}(${argName}, ${accessMessageField}[i]);`);
         } else {
           // if the subtype is not complex its a simple low-level operation
-          lines.push(`  ${argName}.${def.type}(${accessMessageField}[i]);`);
+          lines.push(`  ${argName}[${sourceString(def.type)}](${accessMessageField}[i]);`);
         }
         lines.push("}"); // close the for-loop
       } else if (def.isComplex ?? false) {
         const defType = findTypeByName(types, def.type);
-        lines.push(`${friendlyName(defType.name)}(${argName}, ${accessMessageField});`);
+        const functionName = functionNamesByType.get(defType.name);
+        if (functionName == undefined) {
+          throw new Error(`No writer function for type '${defType.name}'`);
+        }
+        lines.push(`${functionName}(${argName}, ${accessMessageField});`);
       } else {
         // Call primitives directly.
-        lines.push(`${argName}.${def.type}(${accessMessageField});`);
+        lines.push(`${argName}[${sourceString(def.type)}](${accessMessageField});`);
       }
     });
     return lines.join("\n    ");
@@ -295,12 +322,13 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
   let calculateSizeJs = "";
 
   namedTypes.forEach((t) => {
+    const functionName = functionNamesByType.get(t.name)!;
     writerJs += `
-  function ${friendlyName(t.name)}(writer, message) {
+  function ${functionName}(writer, message) {
     ${constructorBody(t, "writer")}
   };\n`;
     calculateSizeJs += `
-  function ${friendlyName(t.name)}(offsetCalculator, message) {
+  function ${functionName}(offsetCalculator, message) {
     ${constructorBody(t, "offsetCalculator")}
   };\n`;
   });

--- a/packages/rosmsg-serialization/src/MessageWriter.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.ts
@@ -234,7 +234,7 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
   if (types.length === 0) {
     throw new Error(`no types given`);
   }
-  validateMessageDefinitionsForCodegen(types, { validateTypeNames: true });
+  validateMessageDefinitionsForCodegen(types);
 
   const unnamedTypes = types.filter((type) => type.name == undefined);
   if (unnamedTypes.length > 1) {

--- a/packages/rosmsg-serialization/src/__snapshots__/LazyMessageReader.test.ts.snap
+++ b/packages/rosmsg-serialization/src/__snapshots__/LazyMessageReader.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LazyReader should deserialize CustomType custom
     ============
@@ -14,7 +14,7 @@ exports[`LazyReader should deserialize CustomType custom
   StandardTypeReader,
 ) {
   class custom_type_CustomType {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -23,13 +23,14 @@ exports[`LazyReader should deserialize CustomType custom
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 first
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -76,13 +77,13 @@ exports[`LazyReader should deserialize CustomType custom
     }
 
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__first$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
 
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __custom$size(view /* dataview */, offset) {
       return custom_type_CustomType.size(view, offset);
     }
 
@@ -91,8 +92,9 @@ exports[`LazyReader should deserialize CustomType custom
       let totalSize = 0;
       let offset = initOffset;
 
+      // custom_type/CustomType custom
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__custom$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -100,7 +102,7 @@ exports[`LazyReader should deserialize CustomType custom
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __custom$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -147,7 +149,7 @@ exports[`LazyReader should deserialize CustomType custom
     }
 
     get custom() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__custom$offset(this.#view, this.#offset);
       return custom_type_CustomType.build(this.#view, offset);
     }
   }
@@ -176,7 +178,7 @@ exports[`LazyReader should deserialize CustomType[] custom
   StandardTypeReader,
 ) {
   class custom_type_MoreCustom {
-    static __field0$size(view /* dataview */, offset) {
+    static __field$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -185,13 +187,14 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 field
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __field$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -238,13 +241,13 @@ exports[`LazyReader should deserialize CustomType[] custom
     }
 
     get field() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__field$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
 
   class custom_type_CustomType {
-    static __field0$size(view /* dataview */, offset) {
+    static __another$size(view /* dataview */, offset) {
       return custom_type_MoreCustom.size(view, offset);
     }
 
@@ -253,8 +256,9 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
+      // custom_type/MoreCustom another
       {
-        const size = custom_type_CustomType.__field0$size(view, offset);
+        const size = custom_type_CustomType.__another$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -262,7 +266,7 @@ exports[`LazyReader should deserialize CustomType[] custom
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __another$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -309,13 +313,13 @@ exports[`LazyReader should deserialize CustomType[] custom
     }
 
     get another() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__another$offset(this.#view, this.#offset);
       return custom_type_MoreCustom.build(this.#view, offset);
     }
   }
 
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __custom$size(view /* dataview */, offset) {
       return builtinSizes.array(view, offset, custom_type_CustomType.size);
     }
 
@@ -324,8 +328,9 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
+      // custom_type/CustomType custom
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__custom$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -333,7 +338,7 @@ exports[`LazyReader should deserialize CustomType[] custom
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __custom$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -379,8 +384,9 @@ exports[`LazyReader should deserialize CustomType[] custom
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // custom_type/CustomType[] custom
     get custom() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__custom$offset(this.#view, this.#offset);
       return deserializers.dynamicArray(
         this.#view,
         offset,
@@ -408,7 +414,7 @@ exports[`LazyReader should deserialize CustomType[] custom
   StandardTypeReader,
 ) {
   class custom_type_CustomType {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -417,13 +423,14 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 first
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -470,13 +477,13 @@ exports[`LazyReader should deserialize CustomType[] custom
     }
 
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__first$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
 
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __custom$size(view /* dataview */, offset) {
       return builtinSizes.array(view, offset, custom_type_CustomType.size);
     }
 
@@ -485,8 +492,9 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
+      // custom_type/CustomType custom
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__custom$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -494,7 +502,7 @@ exports[`LazyReader should deserialize CustomType[] custom
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __custom$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -540,8 +548,9 @@ exports[`LazyReader should deserialize CustomType[] custom
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // custom_type/CustomType[] custom
     get custom() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__custom$offset(this.#view, this.#offset);
       return deserializers.dynamicArray(
         this.#view,
         offset,
@@ -569,7 +578,7 @@ exports[`LazyReader should deserialize CustomType[3] custom
   StandardTypeReader,
 ) {
   class custom_type_CustomType {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -578,13 +587,14 @@ exports[`LazyReader should deserialize CustomType[3] custom
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 first
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -631,13 +641,13 @@ exports[`LazyReader should deserialize CustomType[3] custom
     }
 
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__first$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
 
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __custom$size(view /* dataview */, offset) {
       return builtinSizes.fixedArray(
         view,
         offset,
@@ -651,8 +661,9 @@ exports[`LazyReader should deserialize CustomType[3] custom
       let totalSize = 0;
       let offset = initOffset;
 
+      // custom_type/CustomType custom
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__custom$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -660,7 +671,7 @@ exports[`LazyReader should deserialize CustomType[3] custom
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __custom$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -706,8 +717,9 @@ exports[`LazyReader should deserialize CustomType[3] custom
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // custom_type/CustomType[3] custom
     get custom() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__custom$offset(this.#view, this.#offset);
       return deserializers.fixedArray(
         this.#view,
         offset,
@@ -730,7 +742,7 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __stamp$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -739,13 +751,14 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // duration stamp
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __stamp$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -792,8 +805,8 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
     }
 
     get stamp() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["duration"](this.#view, offset);
+      const offset = this.__stamp$offset(this.#view, this.#offset);
+      return deserializers.duration(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -809,7 +822,7 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 2`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __stamp$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -818,13 +831,14 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 2`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // duration stamp
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __stamp$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -871,8 +885,8 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 2`] = `
     }
 
     get stamp() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["duration"](this.#view, offset);
+      const offset = this.__stamp$offset(this.#view, this.#offset);
+      return deserializers.duration(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -888,7 +902,7 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 8;
     }
@@ -898,8 +912,9 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // duration arr
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__arr$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -907,7 +922,7 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __arr$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -953,10 +968,11 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // duration[] arr
     get arr() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__arr$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["durationArray"](this.#view, offset + 4, len);
+      return deserializers.durationArray(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -972,7 +988,7 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       return 8 * 1;
     }
 
@@ -981,13 +997,14 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // duration[1] arr
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __arr$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1033,9 +1050,10 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // duration[1] arr
     get arr() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["durationArray"](this.#view, offset, 1);
+      const offset = this.__arr$offset(this.#view, this.#offset);
+      return deserializers.durationArray(this.#view, offset, 1);
     }
   }
   return __RootMsg;
@@ -1051,7 +1069,7 @@ exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -1060,13 +1078,14 @@ exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // float32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1113,8 +1132,8 @@ exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["float32"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.float32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1130,7 +1149,7 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -1140,8 +1159,9 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // float32 arr
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__arr$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -1149,7 +1169,7 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __arr$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1195,10 +1215,11 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // float32[] arr
     get arr() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__arr$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["float32Array"](this.#view, offset + 4, len);
+      return deserializers.float32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1216,12 +1237,12 @@ float32[] second 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
 
-    static __field1$size(view /* dataview */, offset) {
+    static __second$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -1231,14 +1252,16 @@ float32[] second 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // float32 first
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__first$size(view, offset);
         totalSize += size;
         offset += size;
       }
 
+      // float32 second
       {
-        const size = __RootMsg.__field1$size(view, offset);
+        const size = __RootMsg.__second$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -1246,18 +1269,17 @@ float32[] second 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
-    __field1$offset(view, initOffset) {
-      if (this.#_field1_offset_cache) {
-        return this.#_field1_offset_cache;
+    __second$offset(view, initOffset) {
+      if (this.#_second_offset_cache) {
+        return this.#_second_offset_cache;
       }
-      const prevOffset = this.__field0$offset(view, initOffset);
-      const totalOffset =
-        prevOffset + __RootMsg.__field0$size(view, prevOffset);
-      this.#_field1_offset_cache = totalOffset;
+      const prevOffset = this.__first$offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.__first$size(view, prevOffset);
+      this.#_second_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -1269,7 +1291,7 @@ float32[] second 1`] = `
 
     #view = undefined;
     #offset;
-    #_field1_offset_cache = undefined;
+    #_second_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -1304,16 +1326,18 @@ float32[] second 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // float32[] first
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__first$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["float32Array"](this.#view, offset + 4, len);
+      return deserializers.float32Array(this.#view, offset + 4, len);
     }
 
+    // float32[] second
     get second() {
-      const offset = this.__field1$offset(this.#view, this.#offset);
+      const offset = this.__second$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["float32Array"](this.#view, offset + 4, len);
+      return deserializers.float32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1329,7 +1353,7 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       return 4 * 2;
     }
 
@@ -1338,13 +1362,14 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // float32[2] arr
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __arr$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1390,9 +1415,10 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // float32[2] arr
     get arr() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["float32Array"](this.#view, offset, 2);
+      const offset = this.__arr$offset(this.#view, this.#offset);
+      return deserializers.float32Array(this.#view, offset, 2);
     }
   }
   return __RootMsg;
@@ -1408,7 +1434,7 @@ exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -1417,13 +1443,14 @@ exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // float64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1470,8 +1497,8 @@ exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["float64"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.float64(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1491,7 +1518,7 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field2$size(view /* dataview */, offset) {
+    static __status$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -1500,13 +1527,14 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
       let totalSize = 0;
       let offset = initOffset;
 
+      // int8 status
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field2$offset(view, initOffset) {
+    __status$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1553,8 +1581,8 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
     }
 
     get status() {
-      const offset = this.__field2$offset(this.#view, this.#offset);
-      return deserializers["int8"](this.#view, offset);
+      const offset = this.__status$offset(this.#view, this.#offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1572,11 +1600,11 @@ int8 second 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __field1$size(view /* dataview */, offset) {
+    static __second$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -1585,27 +1613,28 @@ int8 second 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // int8 first
       totalSize += 1;
       offset += 1;
 
+      // int8 second
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
-    __field1$offset(view, initOffset) {
-      if (this.#_field1_offset_cache) {
-        return this.#_field1_offset_cache;
+    __second$offset(view, initOffset) {
+      if (this.#_second_offset_cache) {
+        return this.#_second_offset_cache;
       }
-      const prevOffset = this.__field0$offset(view, initOffset);
-      const totalOffset =
-        prevOffset + __RootMsg.__field0$size(view, prevOffset);
-      this.#_field1_offset_cache = totalOffset;
+      const prevOffset = this.__first$offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.__first$size(view, prevOffset);
+      this.#_second_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -1617,7 +1646,7 @@ int8 second 1`] = `
 
     #view = undefined;
     #offset;
-    #_field1_offset_cache = undefined;
+    #_second_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -1653,12 +1682,12 @@ int8 second 1`] = `
     }
 
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int8"](this.#view, offset);
+      const offset = this.__first$offset(this.#view, this.#offset);
+      return deserializers.int8(this.#view, offset);
     }
     get second() {
-      const offset = this.__field1$offset(this.#view, this.#offset);
-      return deserializers["int8"](this.#view, offset);
+      const offset = this.__second$offset(this.#view, this.#offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1674,7 +1703,7 @@ exports[`LazyReader should deserialize int8 sample # highest: int8 sample # high
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -1683,13 +1712,14 @@ exports[`LazyReader should deserialize int8 sample # highest: int8 sample # high
       let totalSize = 0;
       let offset = initOffset;
 
+      // int8 sample
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1736,8 +1766,8 @@ exports[`LazyReader should deserialize int8 sample # highest: int8 sample # high
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int8"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1753,7 +1783,7 @@ exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowes
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -1762,13 +1792,14 @@ exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowes
       let totalSize = 0;
       let offset = initOffset;
 
+      // int8 sample
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1815,8 +1846,8 @@ exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowes
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int8"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1832,7 +1863,7 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 1;
     }
@@ -1842,8 +1873,9 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // int8 first
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__first$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -1851,7 +1883,7 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1897,10 +1929,11 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // int8[] first
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__first$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["int8Array"](this.#view, offset + 4, len);
+      return deserializers.int8Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1916,7 +1949,7 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       return 1 * 4;
     }
 
@@ -1925,13 +1958,14 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // int8[4] first
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1977,9 +2011,10 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // int8[4] first
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int8Array"](this.#view, offset, 4);
+      const offset = this.__first$offset(this.#view, this.#offset);
+      return deserializers.int8Array(this.#view, offset, 4);
     }
   }
   return __RootMsg;
@@ -1995,7 +2030,7 @@ exports[`LazyReader should deserialize int16 sample # highest: int16 sample # hi
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 2;
     }
 
@@ -2004,13 +2039,14 @@ exports[`LazyReader should deserialize int16 sample # highest: int16 sample # hi
       let totalSize = 0;
       let offset = initOffset;
 
+      // int16 sample
       totalSize += 2;
       offset += 2;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2057,8 +2093,8 @@ exports[`LazyReader should deserialize int16 sample # highest: int16 sample # hi
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int16"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.int16(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2074,7 +2110,7 @@ exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # low
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 2;
     }
 
@@ -2083,13 +2119,14 @@ exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # low
       let totalSize = 0;
       let offset = initOffset;
 
+      // int16 sample
       totalSize += 2;
       offset += 2;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2136,8 +2173,8 @@ exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # low
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int16"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.int16(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2153,7 +2190,7 @@ exports[`LazyReader should deserialize int32 sample # highest: int32 sample # hi
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -2162,13 +2199,14 @@ exports[`LazyReader should deserialize int32 sample # highest: int32 sample # hi
       let totalSize = 0;
       let offset = initOffset;
 
+      // int32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2215,8 +2253,8 @@ exports[`LazyReader should deserialize int32 sample # highest: int32 sample # hi
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int32"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.int32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2232,7 +2270,7 @@ exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # low
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -2241,13 +2279,14 @@ exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # low
       let totalSize = 0;
       let offset = initOffset;
 
+      // int32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2294,8 +2333,8 @@ exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # low
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int32"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.int32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2311,7 +2350,7 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -2321,8 +2360,9 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // int32 arr
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__arr$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2330,7 +2370,7 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __arr$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2376,10 +2416,11 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // int32[] arr
     get arr() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__arr$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["int32Array"](this.#view, offset + 4, len);
+      return deserializers.int32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -2395,7 +2436,7 @@ exports[`LazyReader should deserialize int64 sample # highest: int64 sample # hi
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -2404,13 +2445,14 @@ exports[`LazyReader should deserialize int64 sample # highest: int64 sample # hi
       let totalSize = 0;
       let offset = initOffset;
 
+      // int64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2457,8 +2499,8 @@ exports[`LazyReader should deserialize int64 sample # highest: int64 sample # hi
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int64"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.int64(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2474,7 +2516,7 @@ exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # low
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -2483,13 +2525,14 @@ exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # low
       let totalSize = 0;
       let offset = initOffset;
 
+      // int64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2536,8 +2579,8 @@ exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # low
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["int64"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.int64(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2555,11 +2598,11 @@ int8 second 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       return builtinSizes.string(view, offset);
     }
 
-    static __field1$size(view /* dataview */, offset) {
+    static __second$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -2568,30 +2611,31 @@ int8 second 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // string first
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__first$size(view, offset);
         totalSize += size;
         offset += size;
       }
 
+      // int8 second
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
-    __field1$offset(view, initOffset) {
-      if (this.#_field1_offset_cache) {
-        return this.#_field1_offset_cache;
+    __second$offset(view, initOffset) {
+      if (this.#_second_offset_cache) {
+        return this.#_second_offset_cache;
       }
-      const prevOffset = this.__field0$offset(view, initOffset);
-      const totalOffset =
-        prevOffset + __RootMsg.__field0$size(view, prevOffset);
-      this.#_field1_offset_cache = totalOffset;
+      const prevOffset = this.__first$offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.__first$size(view, prevOffset);
+      this.#_second_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -2603,7 +2647,7 @@ int8 second 1`] = `
 
     #view = undefined;
     #offset;
-    #_field1_offset_cache = undefined;
+    #_second_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -2639,12 +2683,12 @@ int8 second 1`] = `
     }
 
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["string"](this.#view, offset);
+      const offset = this.__first$offset(this.#view, this.#offset);
+      return deserializers.string(this.#view, offset);
     }
     get second() {
-      const offset = this.__field1$offset(this.#view, this.#offset);
-      return deserializers["int8"](this.#view, offset);
+      const offset = this.__second$offset(this.#view, this.#offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2660,7 +2704,7 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return builtinSizes.string(view, offset);
     }
 
@@ -2669,8 +2713,9 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
       let totalSize = 0;
       let offset = initOffset;
 
+      // string sample
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__sample$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2678,7 +2723,7 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2725,8 +2770,8 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["string"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.string(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2742,7 +2787,7 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return builtinSizes.string(view, offset);
     }
 
@@ -2751,8 +2796,9 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
       let totalSize = 0;
       let offset = initOffset;
 
+      // string sample
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__sample$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2760,7 +2806,7 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2807,8 +2853,8 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["string"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.string(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2824,7 +2870,7 @@ exports[`LazyReader should deserialize string sample: string sample 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return builtinSizes.string(view, offset);
     }
 
@@ -2833,8 +2879,9 @@ exports[`LazyReader should deserialize string sample: string sample 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // string sample
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__sample$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2842,7 +2889,7 @@ exports[`LazyReader should deserialize string sample: string sample 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2889,8 +2936,8 @@ exports[`LazyReader should deserialize string sample: string sample 1`] = `
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["string"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.string(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2906,7 +2953,7 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       return builtinSizes.array(view, offset, builtinSizes.string);
     }
 
@@ -2915,8 +2962,9 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // string first
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__first$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2924,7 +2972,7 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2970,13 +3018,14 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // string[] first
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__first$offset(this.#view, this.#offset);
       return deserializers.dynamicArray(
         this.#view,
         offset,
-        deserializers["string"],
-        builtinSizes["string"],
+        deserializers.string,
+        builtinSizes.string,
       );
     }
   }
@@ -2993,7 +3042,7 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       return builtinSizes.fixedArray(view, offset, 2, builtinSizes.string);
     }
 
@@ -3002,8 +3051,9 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // string first
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__first$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3011,7 +3061,7 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3057,14 +3107,15 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // string[2] first
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__first$offset(this.#view, this.#offset);
       return deserializers.fixedArray(
         this.#view,
         offset,
         2,
-        deserializers["string"],
-        builtinSizes["string"],
+        deserializers.string,
+        builtinSizes.string,
       );
     }
   }
@@ -3081,7 +3132,7 @@ exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __stamp$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -3090,13 +3141,14 @@ exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // time stamp
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __stamp$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3143,8 +3195,8 @@ exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
     }
 
     get stamp() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["time"](this.#view, offset);
+      const offset = this.__stamp$offset(this.#view, this.#offset);
+      return deserializers.time(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3160,7 +3212,7 @@ exports[`LazyReader should deserialize time stamp: time stamp 2`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __stamp$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -3169,13 +3221,14 @@ exports[`LazyReader should deserialize time stamp: time stamp 2`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // time stamp
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __stamp$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3222,8 +3275,8 @@ exports[`LazyReader should deserialize time stamp: time stamp 2`] = `
     }
 
     get stamp() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["time"](this.#view, offset);
+      const offset = this.__stamp$offset(this.#view, this.#offset);
+      return deserializers.time(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3239,7 +3292,7 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 8;
     }
@@ -3249,8 +3302,9 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // time arr
       {
-        const size = __RootMsg.__field0$size(view, offset);
+        const size = __RootMsg.__arr$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3258,7 +3312,7 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __arr$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3304,10 +3358,11 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // time[] arr
     get arr() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
+      const offset = this.__arr$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["timeArray"](this.#view, offset + 4, len);
+      return deserializers.timeArray(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3323,7 +3378,7 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       return 8 * 1;
     }
 
@@ -3332,13 +3387,14 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // time[1] arr
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __arr$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3384,9 +3440,10 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // time[1] arr
     get arr() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["timeArray"](this.#view, offset, 1);
+      const offset = this.__arr$offset(this.#view, this.#offset);
+      return deserializers.timeArray(this.#view, offset, 1);
     }
   }
   return __RootMsg;
@@ -3404,11 +3461,11 @@ float32[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __blank$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __field1$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -3418,11 +3475,13 @@ float32[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 blank
       totalSize += 1;
       offset += 1;
 
+      // float32 arr
       {
-        const size = __RootMsg.__field1$size(view, offset);
+        const size = __RootMsg.__arr$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3430,18 +3489,17 @@ float32[] arr 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __blank$offset(view, initOffset) {
       return initOffset;
     }
 
-    __field1$offset(view, initOffset) {
-      if (this.#_field1_offset_cache) {
-        return this.#_field1_offset_cache;
+    __arr$offset(view, initOffset) {
+      if (this.#_arr_offset_cache) {
+        return this.#_arr_offset_cache;
       }
-      const prevOffset = this.__field0$offset(view, initOffset);
-      const totalOffset =
-        prevOffset + __RootMsg.__field0$size(view, prevOffset);
-      this.#_field1_offset_cache = totalOffset;
+      const prevOffset = this.__blank$offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.__blank$size(view, prevOffset);
+      this.#_arr_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -3453,7 +3511,7 @@ float32[] arr 1`] = `
 
     #view = undefined;
     #offset;
-    #_field1_offset_cache = undefined;
+    #_arr_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -3489,14 +3547,15 @@ float32[] arr 1`] = `
     }
 
     get blank() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__blank$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
 
+    // float32[] arr
     get arr() {
-      const offset = this.__field1$offset(this.#view, this.#offset);
+      const offset = this.__arr$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["float32Array"](this.#view, offset + 4, len);
+      return deserializers.float32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3514,11 +3573,11 @@ float32[2] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __blank$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __field1$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       return 4 * 2;
     }
 
@@ -3527,27 +3586,28 @@ float32[2] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 blank
       totalSize += 1;
       offset += 1;
 
+      // float32[2] arr
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __blank$offset(view, initOffset) {
       return initOffset;
     }
 
-    __field1$offset(view, initOffset) {
-      if (this.#_field1_offset_cache) {
-        return this.#_field1_offset_cache;
+    __arr$offset(view, initOffset) {
+      if (this.#_arr_offset_cache) {
+        return this.#_arr_offset_cache;
       }
-      const prevOffset = this.__field0$offset(view, initOffset);
-      const totalOffset =
-        prevOffset + __RootMsg.__field0$size(view, prevOffset);
-      this.#_field1_offset_cache = totalOffset;
+      const prevOffset = this.__blank$offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.__blank$size(view, prevOffset);
+      this.#_arr_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -3559,7 +3619,7 @@ float32[2] arr 1`] = `
 
     #view = undefined;
     #offset;
-    #_field1_offset_cache = undefined;
+    #_arr_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -3595,13 +3655,14 @@ float32[2] arr 1`] = `
     }
 
     get blank() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__blank$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
 
+    // float32[2] arr
     get arr() {
-      const offset = this.__field1$offset(this.#view, this.#offset);
-      return deserializers["float32Array"](this.#view, offset, 2);
+      const offset = this.__arr$offset(this.#view, this.#offset);
+      return deserializers.float32Array(this.#view, offset, 2);
     }
   }
   return __RootMsg;
@@ -3619,11 +3680,11 @@ int32[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __blank$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __field1$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -3633,11 +3694,13 @@ int32[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 blank
       totalSize += 1;
       offset += 1;
 
+      // int32 arr
       {
-        const size = __RootMsg.__field1$size(view, offset);
+        const size = __RootMsg.__arr$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3645,18 +3708,17 @@ int32[] arr 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __blank$offset(view, initOffset) {
       return initOffset;
     }
 
-    __field1$offset(view, initOffset) {
-      if (this.#_field1_offset_cache) {
-        return this.#_field1_offset_cache;
+    __arr$offset(view, initOffset) {
+      if (this.#_arr_offset_cache) {
+        return this.#_arr_offset_cache;
       }
-      const prevOffset = this.__field0$offset(view, initOffset);
-      const totalOffset =
-        prevOffset + __RootMsg.__field0$size(view, prevOffset);
-      this.#_field1_offset_cache = totalOffset;
+      const prevOffset = this.__blank$offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.__blank$size(view, prevOffset);
+      this.#_arr_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -3668,7 +3730,7 @@ int32[] arr 1`] = `
 
     #view = undefined;
     #offset;
-    #_field1_offset_cache = undefined;
+    #_arr_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -3704,14 +3766,15 @@ int32[] arr 1`] = `
     }
 
     get blank() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__blank$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
 
+    // int32[] arr
     get arr() {
-      const offset = this.__field1$offset(this.#view, this.#offset);
+      const offset = this.__arr$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["int32Array"](this.#view, offset + 4, len);
+      return deserializers.int32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3729,11 +3792,11 @@ time[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __blank$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __field1$size(view /* dataview */, offset) {
+    static __arr$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 8;
     }
@@ -3743,11 +3806,13 @@ time[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 blank
       totalSize += 1;
       offset += 1;
 
+      // time arr
       {
-        const size = __RootMsg.__field1$size(view, offset);
+        const size = __RootMsg.__arr$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3755,18 +3820,17 @@ time[] arr 1`] = `
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __blank$offset(view, initOffset) {
       return initOffset;
     }
 
-    __field1$offset(view, initOffset) {
-      if (this.#_field1_offset_cache) {
-        return this.#_field1_offset_cache;
+    __arr$offset(view, initOffset) {
+      if (this.#_arr_offset_cache) {
+        return this.#_arr_offset_cache;
       }
-      const prevOffset = this.__field0$offset(view, initOffset);
-      const totalOffset =
-        prevOffset + __RootMsg.__field0$size(view, prevOffset);
-      this.#_field1_offset_cache = totalOffset;
+      const prevOffset = this.__blank$offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.__blank$size(view, prevOffset);
+      this.#_arr_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -3778,7 +3842,7 @@ time[] arr 1`] = `
 
     #view = undefined;
     #offset;
-    #_field1_offset_cache = undefined;
+    #_arr_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -3814,14 +3878,15 @@ time[] arr 1`] = `
     }
 
     get blank() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__blank$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
 
+    // time[] arr
     get arr() {
-      const offset = this.__field1$offset(this.#view, this.#offset);
+      const offset = this.__arr$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers["timeArray"](this.#view, offset + 4, len);
+      return deserializers.timeArray(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3837,7 +3902,7 @@ exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # hi
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -3846,13 +3911,14 @@ exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # hi
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 sample
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3899,8 +3965,8 @@ exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # hi
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3916,7 +3982,7 @@ exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # low
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -3925,13 +3991,14 @@ exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # low
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8 sample
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3978,8 +4045,8 @@ exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # low
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3995,7 +4062,7 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __first$size(view /* dataview */, offset) {
       return 1 * 4;
     }
 
@@ -4004,13 +4071,14 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint8[4] first
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __first$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4056,9 +4124,10 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
+    // uint8[4] first
     get first() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint8Array"](this.#view, offset, 4);
+      const offset = this.__first$offset(this.#view, this.#offset);
+      return deserializers.uint8Array(this.#view, offset, 4);
     }
   }
   return __RootMsg;
@@ -4074,7 +4143,7 @@ exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # 
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 2;
     }
 
@@ -4083,13 +4152,14 @@ exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # 
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint16 sample
       totalSize += 2;
       offset += 2;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4136,8 +4206,8 @@ exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # 
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint16"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.uint16(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4153,7 +4223,7 @@ exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # l
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 2;
     }
 
@@ -4162,13 +4232,14 @@ exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # l
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint16 sample
       totalSize += 2;
       offset += 2;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4215,8 +4286,8 @@ exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # l
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint16"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.uint16(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4232,7 +4303,7 @@ exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # 
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -4241,13 +4312,14 @@ exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # 
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4294,8 +4366,8 @@ exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # 
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint32"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.uint32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4311,7 +4383,7 @@ exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # l
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -4320,13 +4392,14 @@ exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # l
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4373,8 +4446,8 @@ exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # l
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint32"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.uint32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4390,7 +4463,7 @@ exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # 
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -4399,13 +4472,14 @@ exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # 
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4452,8 +4526,8 @@ exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # 
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint64"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.uint64(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4469,7 +4543,7 @@ exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # l
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __field0$size(view /* dataview */, offset) {
+    static __sample$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -4478,13 +4552,14 @@ exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # l
       let totalSize = 0;
       let offset = initOffset;
 
+      // uint64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __field0$offset(view, initOffset) {
+    __sample$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4531,8 +4606,8 @@ exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # l
     }
 
     get sample() {
-      const offset = this.__field0$offset(this.#view, this.#offset);
-      return deserializers["uint64"](this.#view, offset);
+      const offset = this.__sample$offset(this.#view, this.#offset);
+      return deserializers.uint64(this.#view, offset);
     }
   }
   return __RootMsg;

--- a/packages/rosmsg-serialization/src/__snapshots__/LazyMessageReader.test.ts.snap
+++ b/packages/rosmsg-serialization/src/__snapshots__/LazyMessageReader.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`LazyReader should deserialize CustomType custom
     ============
@@ -14,7 +14,7 @@ exports[`LazyReader should deserialize CustomType custom
   StandardTypeReader,
 ) {
   class custom_type_CustomType {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -23,14 +23,13 @@ exports[`LazyReader should deserialize CustomType custom
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 first
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -77,13 +76,13 @@ exports[`LazyReader should deserialize CustomType custom
     }
 
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
   }
 
   class __RootMsg {
-    static __custom$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return custom_type_CustomType.size(view, offset);
     }
 
@@ -92,9 +91,8 @@ exports[`LazyReader should deserialize CustomType custom
       let totalSize = 0;
       let offset = initOffset;
 
-      // custom_type/CustomType custom
       {
-        const size = __RootMsg.__custom$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -102,7 +100,7 @@ exports[`LazyReader should deserialize CustomType custom
       return totalSize;
     }
 
-    __custom$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -149,7 +147,7 @@ exports[`LazyReader should deserialize CustomType custom
     }
 
     get custom() {
-      const offset = this.__custom$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       return custom_type_CustomType.build(this.#view, offset);
     }
   }
@@ -178,7 +176,7 @@ exports[`LazyReader should deserialize CustomType[] custom
   StandardTypeReader,
 ) {
   class custom_type_MoreCustom {
-    static __field$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -187,14 +185,13 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 field
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __field$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -241,13 +238,13 @@ exports[`LazyReader should deserialize CustomType[] custom
     }
 
     get field() {
-      const offset = this.__field$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
   }
 
   class custom_type_CustomType {
-    static __another$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return custom_type_MoreCustom.size(view, offset);
     }
 
@@ -256,9 +253,8 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
-      // custom_type/MoreCustom another
       {
-        const size = custom_type_CustomType.__another$size(view, offset);
+        const size = custom_type_CustomType.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -266,7 +262,7 @@ exports[`LazyReader should deserialize CustomType[] custom
       return totalSize;
     }
 
-    __another$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -313,13 +309,13 @@ exports[`LazyReader should deserialize CustomType[] custom
     }
 
     get another() {
-      const offset = this.__another$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       return custom_type_MoreCustom.build(this.#view, offset);
     }
   }
 
   class __RootMsg {
-    static __custom$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return builtinSizes.array(view, offset, custom_type_CustomType.size);
     }
 
@@ -328,9 +324,8 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
-      // custom_type/CustomType custom
       {
-        const size = __RootMsg.__custom$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -338,7 +333,7 @@ exports[`LazyReader should deserialize CustomType[] custom
       return totalSize;
     }
 
-    __custom$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -384,9 +379,8 @@ exports[`LazyReader should deserialize CustomType[] custom
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // custom_type/CustomType[] custom
     get custom() {
-      const offset = this.__custom$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       return deserializers.dynamicArray(
         this.#view,
         offset,
@@ -414,7 +408,7 @@ exports[`LazyReader should deserialize CustomType[] custom
   StandardTypeReader,
 ) {
   class custom_type_CustomType {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -423,14 +417,13 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 first
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -477,13 +470,13 @@ exports[`LazyReader should deserialize CustomType[] custom
     }
 
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
   }
 
   class __RootMsg {
-    static __custom$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return builtinSizes.array(view, offset, custom_type_CustomType.size);
     }
 
@@ -492,9 +485,8 @@ exports[`LazyReader should deserialize CustomType[] custom
       let totalSize = 0;
       let offset = initOffset;
 
-      // custom_type/CustomType custom
       {
-        const size = __RootMsg.__custom$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -502,7 +494,7 @@ exports[`LazyReader should deserialize CustomType[] custom
       return totalSize;
     }
 
-    __custom$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -548,9 +540,8 @@ exports[`LazyReader should deserialize CustomType[] custom
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // custom_type/CustomType[] custom
     get custom() {
-      const offset = this.__custom$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       return deserializers.dynamicArray(
         this.#view,
         offset,
@@ -578,7 +569,7 @@ exports[`LazyReader should deserialize CustomType[3] custom
   StandardTypeReader,
 ) {
   class custom_type_CustomType {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -587,14 +578,13 @@ exports[`LazyReader should deserialize CustomType[3] custom
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 first
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -641,13 +631,13 @@ exports[`LazyReader should deserialize CustomType[3] custom
     }
 
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
   }
 
   class __RootMsg {
-    static __custom$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return builtinSizes.fixedArray(
         view,
         offset,
@@ -661,9 +651,8 @@ exports[`LazyReader should deserialize CustomType[3] custom
       let totalSize = 0;
       let offset = initOffset;
 
-      // custom_type/CustomType custom
       {
-        const size = __RootMsg.__custom$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -671,7 +660,7 @@ exports[`LazyReader should deserialize CustomType[3] custom
       return totalSize;
     }
 
-    __custom$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -717,9 +706,8 @@ exports[`LazyReader should deserialize CustomType[3] custom
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // custom_type/CustomType[3] custom
     get custom() {
-      const offset = this.__custom$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       return deserializers.fixedArray(
         this.#view,
         offset,
@@ -742,7 +730,7 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __stamp$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -751,14 +739,13 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // duration stamp
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __stamp$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -805,8 +792,8 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
     }
 
     get stamp() {
-      const offset = this.__stamp$offset(this.#view, this.#offset);
-      return deserializers.duration(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["duration"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -822,7 +809,7 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 2`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __stamp$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -831,14 +818,13 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 2`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // duration stamp
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __stamp$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -885,8 +871,8 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 2`] = `
     }
 
     get stamp() {
-      const offset = this.__stamp$offset(this.#view, this.#offset);
-      return deserializers.duration(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["duration"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -902,7 +888,7 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __arr$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 8;
     }
@@ -912,9 +898,8 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // duration arr
       {
-        const size = __RootMsg.__arr$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -922,7 +907,7 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
       return totalSize;
     }
 
-    __arr$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -968,11 +953,10 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // duration[] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.durationArray(this.#view, offset + 4, len);
+      return deserializers["durationArray"](this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -988,7 +972,7 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __arr$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8 * 1;
     }
 
@@ -997,14 +981,13 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // duration[1] arr
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __arr$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1050,10 +1033,9 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // duration[1] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
-      return deserializers.durationArray(this.#view, offset, 1);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["durationArray"](this.#view, offset, 1);
     }
   }
   return __RootMsg;
@@ -1069,7 +1051,7 @@ exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -1078,14 +1060,13 @@ exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // float32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1132,8 +1113,8 @@ exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.float32(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["float32"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1149,7 +1130,7 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __arr$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -1159,9 +1140,8 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // float32 arr
       {
-        const size = __RootMsg.__arr$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -1169,7 +1149,7 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
       return totalSize;
     }
 
-    __arr$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1215,11 +1195,10 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // float32[] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.float32Array(this.#view, offset + 4, len);
+      return deserializers["float32Array"](this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1237,12 +1216,12 @@ float32[] second 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
 
-    static __second$size(view /* dataview */, offset) {
+    static __field1$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -1252,16 +1231,14 @@ float32[] second 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // float32 first
       {
-        const size = __RootMsg.__first$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
 
-      // float32 second
       {
-        const size = __RootMsg.__second$size(view, offset);
+        const size = __RootMsg.__field1$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -1269,17 +1246,18 @@ float32[] second 1`] = `
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
-    __second$offset(view, initOffset) {
-      if (this.#_second_offset_cache) {
-        return this.#_second_offset_cache;
+    __field1$offset(view, initOffset) {
+      if (this.#_field1_offset_cache) {
+        return this.#_field1_offset_cache;
       }
-      const prevOffset = this.__first$offset(view, initOffset);
-      const totalOffset = prevOffset + __RootMsg.__first$size(view, prevOffset);
-      this.#_second_offset_cache = totalOffset;
+      const prevOffset = this.__field0$offset(view, initOffset);
+      const totalOffset =
+        prevOffset + __RootMsg.__field0$size(view, prevOffset);
+      this.#_field1_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -1291,7 +1269,7 @@ float32[] second 1`] = `
 
     #view = undefined;
     #offset;
-    #_second_offset_cache = undefined;
+    #_field1_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -1326,18 +1304,16 @@ float32[] second 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // float32[] first
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.float32Array(this.#view, offset + 4, len);
+      return deserializers["float32Array"](this.#view, offset + 4, len);
     }
 
-    // float32[] second
     get second() {
-      const offset = this.__second$offset(this.#view, this.#offset);
+      const offset = this.__field1$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.float32Array(this.#view, offset + 4, len);
+      return deserializers["float32Array"](this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1353,7 +1329,7 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __arr$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 4 * 2;
     }
 
@@ -1362,14 +1338,13 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // float32[2] arr
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __arr$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1415,10 +1390,9 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // float32[2] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
-      return deserializers.float32Array(this.#view, offset, 2);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["float32Array"](this.#view, offset, 2);
     }
   }
   return __RootMsg;
@@ -1434,7 +1408,7 @@ exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -1443,14 +1417,13 @@ exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // float64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1497,8 +1470,8 @@ exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.float64(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["float64"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1518,7 +1491,7 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __status$size(view /* dataview */, offset) {
+    static __field2$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -1527,14 +1500,13 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
       let totalSize = 0;
       let offset = initOffset;
 
-      // int8 status
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __status$offset(view, initOffset) {
+    __field2$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1581,8 +1553,8 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
     }
 
     get status() {
-      const offset = this.__status$offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.__field2$offset(this.#view, this.#offset);
+      return deserializers["int8"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1600,11 +1572,11 @@ int8 second 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __second$size(view /* dataview */, offset) {
+    static __field1$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -1613,28 +1585,27 @@ int8 second 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // int8 first
       totalSize += 1;
       offset += 1;
 
-      // int8 second
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
-    __second$offset(view, initOffset) {
-      if (this.#_second_offset_cache) {
-        return this.#_second_offset_cache;
+    __field1$offset(view, initOffset) {
+      if (this.#_field1_offset_cache) {
+        return this.#_field1_offset_cache;
       }
-      const prevOffset = this.__first$offset(view, initOffset);
-      const totalOffset = prevOffset + __RootMsg.__first$size(view, prevOffset);
-      this.#_second_offset_cache = totalOffset;
+      const prevOffset = this.__field0$offset(view, initOffset);
+      const totalOffset =
+        prevOffset + __RootMsg.__field0$size(view, prevOffset);
+      this.#_field1_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -1646,7 +1617,7 @@ int8 second 1`] = `
 
     #view = undefined;
     #offset;
-    #_second_offset_cache = undefined;
+    #_field1_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -1682,12 +1653,12 @@ int8 second 1`] = `
     }
 
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int8"](this.#view, offset);
     }
     get second() {
-      const offset = this.__second$offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.__field1$offset(this.#view, this.#offset);
+      return deserializers["int8"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1703,7 +1674,7 @@ exports[`LazyReader should deserialize int8 sample # highest: int8 sample # high
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -1712,14 +1683,13 @@ exports[`LazyReader should deserialize int8 sample # highest: int8 sample # high
       let totalSize = 0;
       let offset = initOffset;
 
-      // int8 sample
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1766,8 +1736,8 @@ exports[`LazyReader should deserialize int8 sample # highest: int8 sample # high
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int8"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1783,7 +1753,7 @@ exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowes
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -1792,14 +1762,13 @@ exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowes
       let totalSize = 0;
       let offset = initOffset;
 
-      // int8 sample
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1846,8 +1815,8 @@ exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowes
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int8"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1863,7 +1832,7 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 1;
     }
@@ -1873,9 +1842,8 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // int8 first
       {
-        const size = __RootMsg.__first$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -1883,7 +1851,7 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -1929,11 +1897,10 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // int8[] first
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.int8Array(this.#view, offset + 4, len);
+      return deserializers["int8Array"](this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1949,7 +1916,7 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1 * 4;
     }
 
@@ -1958,14 +1925,13 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // int8[4] first
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2011,10 +1977,9 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // int8[4] first
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
-      return deserializers.int8Array(this.#view, offset, 4);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int8Array"](this.#view, offset, 4);
     }
   }
   return __RootMsg;
@@ -2030,7 +1995,7 @@ exports[`LazyReader should deserialize int16 sample # highest: int16 sample # hi
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 2;
     }
 
@@ -2039,14 +2004,13 @@ exports[`LazyReader should deserialize int16 sample # highest: int16 sample # hi
       let totalSize = 0;
       let offset = initOffset;
 
-      // int16 sample
       totalSize += 2;
       offset += 2;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2093,8 +2057,8 @@ exports[`LazyReader should deserialize int16 sample # highest: int16 sample # hi
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.int16(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int16"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2110,7 +2074,7 @@ exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # low
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 2;
     }
 
@@ -2119,14 +2083,13 @@ exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # low
       let totalSize = 0;
       let offset = initOffset;
 
-      // int16 sample
       totalSize += 2;
       offset += 2;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2173,8 +2136,8 @@ exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # low
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.int16(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int16"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2190,7 +2153,7 @@ exports[`LazyReader should deserialize int32 sample # highest: int32 sample # hi
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -2199,14 +2162,13 @@ exports[`LazyReader should deserialize int32 sample # highest: int32 sample # hi
       let totalSize = 0;
       let offset = initOffset;
 
-      // int32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2253,8 +2215,8 @@ exports[`LazyReader should deserialize int32 sample # highest: int32 sample # hi
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.int32(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int32"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2270,7 +2232,7 @@ exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # low
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -2279,14 +2241,13 @@ exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # low
       let totalSize = 0;
       let offset = initOffset;
 
-      // int32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2333,8 +2294,8 @@ exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # low
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.int32(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int32"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2350,7 +2311,7 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __arr$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -2360,9 +2321,8 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // int32 arr
       {
-        const size = __RootMsg.__arr$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2370,7 +2330,7 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
       return totalSize;
     }
 
-    __arr$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2416,11 +2376,10 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // int32[] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.int32Array(this.#view, offset + 4, len);
+      return deserializers["int32Array"](this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -2436,7 +2395,7 @@ exports[`LazyReader should deserialize int64 sample # highest: int64 sample # hi
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -2445,14 +2404,13 @@ exports[`LazyReader should deserialize int64 sample # highest: int64 sample # hi
       let totalSize = 0;
       let offset = initOffset;
 
-      // int64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2499,8 +2457,8 @@ exports[`LazyReader should deserialize int64 sample # highest: int64 sample # hi
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.int64(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int64"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2516,7 +2474,7 @@ exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # low
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -2525,14 +2483,13 @@ exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # low
       let totalSize = 0;
       let offset = initOffset;
 
-      // int64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2579,8 +2536,8 @@ exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # low
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.int64(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["int64"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2598,11 +2555,11 @@ int8 second 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return builtinSizes.string(view, offset);
     }
 
-    static __second$size(view /* dataview */, offset) {
+    static __field1$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -2611,31 +2568,30 @@ int8 second 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // string first
       {
-        const size = __RootMsg.__first$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
 
-      // int8 second
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
-    __second$offset(view, initOffset) {
-      if (this.#_second_offset_cache) {
-        return this.#_second_offset_cache;
+    __field1$offset(view, initOffset) {
+      if (this.#_field1_offset_cache) {
+        return this.#_field1_offset_cache;
       }
-      const prevOffset = this.__first$offset(view, initOffset);
-      const totalOffset = prevOffset + __RootMsg.__first$size(view, prevOffset);
-      this.#_second_offset_cache = totalOffset;
+      const prevOffset = this.__field0$offset(view, initOffset);
+      const totalOffset =
+        prevOffset + __RootMsg.__field0$size(view, prevOffset);
+      this.#_field1_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -2647,7 +2603,7 @@ int8 second 1`] = `
 
     #view = undefined;
     #offset;
-    #_second_offset_cache = undefined;
+    #_field1_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -2683,12 +2639,12 @@ int8 second 1`] = `
     }
 
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
-      return deserializers.string(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["string"](this.#view, offset);
     }
     get second() {
-      const offset = this.__second$offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.__field1$offset(this.#view, this.#offset);
+      return deserializers["int8"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2704,7 +2660,7 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return builtinSizes.string(view, offset);
     }
 
@@ -2713,9 +2669,8 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
       let totalSize = 0;
       let offset = initOffset;
 
-      // string sample
       {
-        const size = __RootMsg.__sample$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2723,7 +2678,7 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2770,8 +2725,8 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.string(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["string"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2787,7 +2742,7 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return builtinSizes.string(view, offset);
     }
 
@@ -2796,9 +2751,8 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
       let totalSize = 0;
       let offset = initOffset;
 
-      // string sample
       {
-        const size = __RootMsg.__sample$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2806,7 +2760,7 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2853,8 +2807,8 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.string(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["string"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2870,7 +2824,7 @@ exports[`LazyReader should deserialize string sample: string sample 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return builtinSizes.string(view, offset);
     }
 
@@ -2879,9 +2833,8 @@ exports[`LazyReader should deserialize string sample: string sample 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // string sample
       {
-        const size = __RootMsg.__sample$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2889,7 +2842,7 @@ exports[`LazyReader should deserialize string sample: string sample 1`] = `
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -2936,8 +2889,8 @@ exports[`LazyReader should deserialize string sample: string sample 1`] = `
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.string(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["string"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2953,7 +2906,7 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return builtinSizes.array(view, offset, builtinSizes.string);
     }
 
@@ -2962,9 +2915,8 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // string first
       {
-        const size = __RootMsg.__first$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -2972,7 +2924,7 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3018,14 +2970,13 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // string[] first
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       return deserializers.dynamicArray(
         this.#view,
         offset,
-        deserializers.string,
-        builtinSizes.string,
+        deserializers["string"],
+        builtinSizes["string"],
       );
     }
   }
@@ -3042,7 +2993,7 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return builtinSizes.fixedArray(view, offset, 2, builtinSizes.string);
     }
 
@@ -3051,9 +3002,8 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // string first
       {
-        const size = __RootMsg.__first$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3061,7 +3011,7 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3107,15 +3057,14 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // string[2] first
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       return deserializers.fixedArray(
         this.#view,
         offset,
         2,
-        deserializers.string,
-        builtinSizes.string,
+        deserializers["string"],
+        builtinSizes["string"],
       );
     }
   }
@@ -3132,7 +3081,7 @@ exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __stamp$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -3141,14 +3090,13 @@ exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // time stamp
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __stamp$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3195,8 +3143,8 @@ exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
     }
 
     get stamp() {
-      const offset = this.__stamp$offset(this.#view, this.#offset);
-      return deserializers.time(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["time"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3212,7 +3160,7 @@ exports[`LazyReader should deserialize time stamp: time stamp 2`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __stamp$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -3221,14 +3169,13 @@ exports[`LazyReader should deserialize time stamp: time stamp 2`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // time stamp
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __stamp$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3275,8 +3222,8 @@ exports[`LazyReader should deserialize time stamp: time stamp 2`] = `
     }
 
     get stamp() {
-      const offset = this.__stamp$offset(this.#view, this.#offset);
-      return deserializers.time(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["time"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3292,7 +3239,7 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __arr$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 8;
     }
@@ -3302,9 +3249,8 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // time arr
       {
-        const size = __RootMsg.__arr$size(view, offset);
+        const size = __RootMsg.__field0$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3312,7 +3258,7 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
       return totalSize;
     }
 
-    __arr$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3358,11 +3304,10 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // time[] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.timeArray(this.#view, offset + 4, len);
+      return deserializers["timeArray"](this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3378,7 +3323,7 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __arr$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8 * 1;
     }
 
@@ -3387,14 +3332,13 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // time[1] arr
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __arr$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3440,10 +3384,9 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // time[1] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
-      return deserializers.timeArray(this.#view, offset, 1);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["timeArray"](this.#view, offset, 1);
     }
   }
   return __RootMsg;
@@ -3461,11 +3404,11 @@ float32[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __blank$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __arr$size(view /* dataview */, offset) {
+    static __field1$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -3475,13 +3418,11 @@ float32[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 blank
       totalSize += 1;
       offset += 1;
 
-      // float32 arr
       {
-        const size = __RootMsg.__arr$size(view, offset);
+        const size = __RootMsg.__field1$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3489,17 +3430,18 @@ float32[] arr 1`] = `
       return totalSize;
     }
 
-    __blank$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
-    __arr$offset(view, initOffset) {
-      if (this.#_arr_offset_cache) {
-        return this.#_arr_offset_cache;
+    __field1$offset(view, initOffset) {
+      if (this.#_field1_offset_cache) {
+        return this.#_field1_offset_cache;
       }
-      const prevOffset = this.__blank$offset(view, initOffset);
-      const totalOffset = prevOffset + __RootMsg.__blank$size(view, prevOffset);
-      this.#_arr_offset_cache = totalOffset;
+      const prevOffset = this.__field0$offset(view, initOffset);
+      const totalOffset =
+        prevOffset + __RootMsg.__field0$size(view, prevOffset);
+      this.#_field1_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -3511,7 +3453,7 @@ float32[] arr 1`] = `
 
     #view = undefined;
     #offset;
-    #_arr_offset_cache = undefined;
+    #_field1_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -3547,15 +3489,14 @@ float32[] arr 1`] = `
     }
 
     get blank() {
-      const offset = this.__blank$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
 
-    // float32[] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
+      const offset = this.__field1$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.float32Array(this.#view, offset + 4, len);
+      return deserializers["float32Array"](this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3573,11 +3514,11 @@ float32[2] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __blank$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __arr$size(view /* dataview */, offset) {
+    static __field1$size(view /* dataview */, offset) {
       return 4 * 2;
     }
 
@@ -3586,28 +3527,27 @@ float32[2] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 blank
       totalSize += 1;
       offset += 1;
 
-      // float32[2] arr
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __blank$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
-    __arr$offset(view, initOffset) {
-      if (this.#_arr_offset_cache) {
-        return this.#_arr_offset_cache;
+    __field1$offset(view, initOffset) {
+      if (this.#_field1_offset_cache) {
+        return this.#_field1_offset_cache;
       }
-      const prevOffset = this.__blank$offset(view, initOffset);
-      const totalOffset = prevOffset + __RootMsg.__blank$size(view, prevOffset);
-      this.#_arr_offset_cache = totalOffset;
+      const prevOffset = this.__field0$offset(view, initOffset);
+      const totalOffset =
+        prevOffset + __RootMsg.__field0$size(view, prevOffset);
+      this.#_field1_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -3619,7 +3559,7 @@ float32[2] arr 1`] = `
 
     #view = undefined;
     #offset;
-    #_arr_offset_cache = undefined;
+    #_field1_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -3655,14 +3595,13 @@ float32[2] arr 1`] = `
     }
 
     get blank() {
-      const offset = this.__blank$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
 
-    // float32[2] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
-      return deserializers.float32Array(this.#view, offset, 2);
+      const offset = this.__field1$offset(this.#view, this.#offset);
+      return deserializers["float32Array"](this.#view, offset, 2);
     }
   }
   return __RootMsg;
@@ -3680,11 +3619,11 @@ int32[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __blank$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __arr$size(view /* dataview */, offset) {
+    static __field1$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 4;
     }
@@ -3694,13 +3633,11 @@ int32[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 blank
       totalSize += 1;
       offset += 1;
 
-      // int32 arr
       {
-        const size = __RootMsg.__arr$size(view, offset);
+        const size = __RootMsg.__field1$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3708,17 +3645,18 @@ int32[] arr 1`] = `
       return totalSize;
     }
 
-    __blank$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
-    __arr$offset(view, initOffset) {
-      if (this.#_arr_offset_cache) {
-        return this.#_arr_offset_cache;
+    __field1$offset(view, initOffset) {
+      if (this.#_field1_offset_cache) {
+        return this.#_field1_offset_cache;
       }
-      const prevOffset = this.__blank$offset(view, initOffset);
-      const totalOffset = prevOffset + __RootMsg.__blank$size(view, prevOffset);
-      this.#_arr_offset_cache = totalOffset;
+      const prevOffset = this.__field0$offset(view, initOffset);
+      const totalOffset =
+        prevOffset + __RootMsg.__field0$size(view, prevOffset);
+      this.#_field1_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -3730,7 +3668,7 @@ int32[] arr 1`] = `
 
     #view = undefined;
     #offset;
-    #_arr_offset_cache = undefined;
+    #_field1_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -3766,15 +3704,14 @@ int32[] arr 1`] = `
     }
 
     get blank() {
-      const offset = this.__blank$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
 
-    // int32[] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
+      const offset = this.__field1$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.int32Array(this.#view, offset + 4, len);
+      return deserializers["int32Array"](this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3792,11 +3729,11 @@ time[] arr 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __blank$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
-    static __arr$size(view /* dataview */, offset) {
+    static __field1$size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
       return 4 + len * 8;
     }
@@ -3806,13 +3743,11 @@ time[] arr 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 blank
       totalSize += 1;
       offset += 1;
 
-      // time arr
       {
-        const size = __RootMsg.__arr$size(view, offset);
+        const size = __RootMsg.__field1$size(view, offset);
         totalSize += size;
         offset += size;
       }
@@ -3820,17 +3755,18 @@ time[] arr 1`] = `
       return totalSize;
     }
 
-    __blank$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
-    __arr$offset(view, initOffset) {
-      if (this.#_arr_offset_cache) {
-        return this.#_arr_offset_cache;
+    __field1$offset(view, initOffset) {
+      if (this.#_field1_offset_cache) {
+        return this.#_field1_offset_cache;
       }
-      const prevOffset = this.__blank$offset(view, initOffset);
-      const totalOffset = prevOffset + __RootMsg.__blank$size(view, prevOffset);
-      this.#_arr_offset_cache = totalOffset;
+      const prevOffset = this.__field0$offset(view, initOffset);
+      const totalOffset =
+        prevOffset + __RootMsg.__field0$size(view, prevOffset);
+      this.#_field1_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -3842,7 +3778,7 @@ time[] arr 1`] = `
 
     #view = undefined;
     #offset;
-    #_arr_offset_cache = undefined;
+    #_field1_offset_cache = undefined;
 
     constructor(view, offset = 0) {
       this.#view = view;
@@ -3878,15 +3814,14 @@ time[] arr 1`] = `
     }
 
     get blank() {
-      const offset = this.__blank$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
 
-    // time[] arr
     get arr() {
-      const offset = this.__arr$offset(this.#view, this.#offset);
+      const offset = this.__field1$offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return deserializers.timeArray(this.#view, offset + 4, len);
+      return deserializers["timeArray"](this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3902,7 +3837,7 @@ exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # hi
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -3911,14 +3846,13 @@ exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # hi
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 sample
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -3965,8 +3899,8 @@ exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # hi
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3982,7 +3916,7 @@ exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # low
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1;
     }
 
@@ -3991,14 +3925,13 @@ exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # low
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8 sample
       totalSize += 1;
       offset += 1;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4045,8 +3978,8 @@ exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # low
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4062,7 +3995,7 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __first$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 1 * 4;
     }
 
@@ -4071,14 +4004,13 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint8[4] first
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __first$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4124,10 +4056,9 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
       return new (typeReaders.get("__RootMsg"))(reader);
     }
 
-    // uint8[4] first
     get first() {
-      const offset = this.__first$offset(this.#view, this.#offset);
-      return deserializers.uint8Array(this.#view, offset, 4);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint8Array"](this.#view, offset, 4);
     }
   }
   return __RootMsg;
@@ -4143,7 +4074,7 @@ exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # 
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 2;
     }
 
@@ -4152,14 +4083,13 @@ exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # 
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint16 sample
       totalSize += 2;
       offset += 2;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4206,8 +4136,8 @@ exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # 
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.uint16(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint16"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4223,7 +4153,7 @@ exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # l
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 2;
     }
 
@@ -4232,14 +4162,13 @@ exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # l
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint16 sample
       totalSize += 2;
       offset += 2;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4286,8 +4215,8 @@ exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # l
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.uint16(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint16"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4303,7 +4232,7 @@ exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # 
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -4312,14 +4241,13 @@ exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # 
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4366,8 +4294,8 @@ exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # 
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.uint32(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint32"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4383,7 +4311,7 @@ exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # l
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 4;
     }
 
@@ -4392,14 +4320,13 @@ exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # l
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint32 sample
       totalSize += 4;
       offset += 4;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4446,8 +4373,8 @@ exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # l
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.uint32(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint32"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4463,7 +4390,7 @@ exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # 
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -4472,14 +4399,13 @@ exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # 
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4526,8 +4452,8 @@ exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # 
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.uint64(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint64"](this.#view, offset);
     }
   }
   return __RootMsg;
@@ -4543,7 +4469,7 @@ exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # l
   StandardTypeReader,
 ) {
   class __RootMsg {
-    static __sample$size(view /* dataview */, offset) {
+    static __field0$size(view /* dataview */, offset) {
       return 8;
     }
 
@@ -4552,14 +4478,13 @@ exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # l
       let totalSize = 0;
       let offset = initOffset;
 
-      // uint64 sample
       totalSize += 8;
       offset += 8;
 
       return totalSize;
     }
 
-    __sample$offset(view, initOffset) {
+    __field0$offset(view, initOffset) {
       return initOffset;
     }
 
@@ -4606,8 +4531,8 @@ exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # l
     }
 
     get sample() {
-      const offset = this.__sample$offset(this.#view, this.#offset);
-      return deserializers.uint64(this.#view, offset);
+      const offset = this.__field0$offset(this.#view, this.#offset);
+      return deserializers["uint64"](this.#view, offset);
     }
   }
   return __RootMsg;

--- a/packages/rosmsg-serialization/src/buildReader.ts
+++ b/packages/rosmsg-serialization/src/buildReader.ts
@@ -239,7 +239,7 @@ function getterFunction(field: MessageDefinitionField): string {
 export default function buildReader(
   definitions: readonly MessageDefinition[],
 ): SerializedMessageReader {
-  validateMessageDefinitionsForCodegen(definitions, { validateTypeNames: true });
+  validateMessageDefinitionsForCodegen(definitions);
 
   const classes = new Array<string>();
   const rootClassName = "__RootMsg";

--- a/packages/rosmsg-serialization/src/buildReader.ts
+++ b/packages/rosmsg-serialization/src/buildReader.ts
@@ -2,6 +2,7 @@ import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-def
 
 import { createParsers, StandardTypeReader } from ".";
 import { deserializers, fixedSizeTypes, FixedSizeTypes } from "./BuiltinDeserialize";
+import { validateMessageDefinitionsForCodegen } from "./validateMessageDefinitions";
 
 const builtinSizes = {
   // strings are the only builtin type that are variable size
@@ -63,37 +64,6 @@ function sanitizeName(name: string): string {
   return name.replace(/^[0-9]|[^a-zA-Z0-9_]/g, "_");
 }
 
-function sourceString(value: string): string {
-  return JSON.stringify(value);
-}
-
-function hasOwn(object: object, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(object, key);
-}
-
-function arrayLengthSource(field: MessageDefinitionField): string {
-  const { arrayLength } = field;
-  if (arrayLength == undefined) {
-    return "undefined";
-  }
-  if (!Number.isSafeInteger(arrayLength) || arrayLength < 0) {
-    throw new Error(`Invalid array length ${String(arrayLength)} for field '${field.name}'`);
-  }
-  return String(arrayLength);
-}
-
-function fieldSizeFunctionName(fieldIndex: number): string {
-  return `__field${fieldIndex}$size`;
-}
-
-function fieldOffsetFunctionName(fieldIndex: number): string {
-  return `__field${fieldIndex}$offset`;
-}
-
-function fieldOffsetCacheName(fieldIndex: number): string {
-  return `#_field${fieldIndex}_offset_cache`;
-}
-
 interface SerializedMessageReader {
   build: (view: DataView, offset?: number) => unknown;
   size: (view: DataView, offset?: number) => number;
@@ -101,13 +71,12 @@ interface SerializedMessageReader {
 }
 
 // Return a static size function for our @param field
-function sizeFunction(field: MessageDefinitionField, fieldIndex: number): string {
+function sizeFunction(field: MessageDefinitionField): string {
   if (field.isConstant === true) {
     return "";
   }
 
   const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
-  const sizeFunctionName = fieldSizeFunctionName(fieldIndex);
 
   // if the field size is not known, size will be calculated on-demand
   if (fieldSize == undefined) {
@@ -118,31 +87,31 @@ function sizeFunction(field: MessageDefinitionField, fieldIndex: number): string
     if (field.isArray === true) {
       if (field.arrayLength != undefined) {
         return `
-          static ${sizeFunctionName}(view /* dataview */, offset) {
-              return builtinSizes.fixedArray(view, offset, ${arrayLengthSource(field)}, ${fieldSizeFn});
+          static __${field.name}$size(view /* dataview */, offset) {
+              return builtinSizes.fixedArray(view, offset, ${field.arrayLength}, ${fieldSizeFn});
           }`;
       } else {
         return `
-          static ${sizeFunctionName}(view /* dataview */, offset) {
+          static __${field.name}$size(view /* dataview */, offset) {
               return builtinSizes.array(view, offset, ${fieldSizeFn});
           }`;
       }
     }
 
     return `
-      static ${sizeFunctionName}(view /* dataview */, offset) {
+      static __${field.name}$size(view /* dataview */, offset) {
           return ${fieldSizeFn}(view, offset);
       }`;
   } else {
     if (field.isArray === true) {
       if (field.arrayLength != undefined) {
         return `
-          static ${sizeFunctionName}(view /* dataview */, offset) {
-            return ${fieldSize} * ${arrayLengthSource(field)};
+          static __${field.name}$size(view /* dataview */, offset) {
+            return ${fieldSize} * ${field.arrayLength};
           }`;
       } else {
         return `
-          static ${sizeFunctionName}(view /* dataview */, offset) {
+          static __${field.name}$size(view /* dataview */, offset) {
             const len = view.getUint32(offset, true);
             return 4 + len * ${fieldSize};
           }`;
@@ -150,18 +119,14 @@ function sizeFunction(field: MessageDefinitionField, fieldIndex: number): string
     }
 
     return `
-      static ${sizeFunctionName}(view /* dataview */, offset) {
+      static __${field.name}$size(view /* dataview */, offset) {
           return ${fieldSize};
       }`;
   }
 }
 
 // Return the part of the static size() function for our message class for @param field
-function sizePartForDefinition(
-  className: string,
-  field: MessageDefinitionField,
-  fieldIndex: number,
-): string {
+function sizePartForDefinition(className: string, field: MessageDefinitionField): string {
   if (field.isConstant === true) {
     return "";
   }
@@ -171,13 +136,15 @@ function sizePartForDefinition(
 
   if (fieldSize != undefined && (isFixedArray || field.isArray === false)) {
     if (field.arrayLength != undefined) {
-      const totalSize = fieldSize * Number(arrayLengthSource(field));
+      const totalSize = fieldSize * field.arrayLength;
       return `
+        // ${field.type}[${field.arrayLength}] ${field.name}
         totalSize += ${totalSize};
         offset += ${totalSize};
       `;
     } else {
       return `
+        // ${field.type} ${field.name}
         totalSize += ${fieldSize};
         offset += ${fieldSize};
       `;
@@ -185,8 +152,9 @@ function sizePartForDefinition(
   }
 
   return `
+    // ${field.type} ${field.name}
     {
-        const size = ${className}.${fieldSizeFunctionName(fieldIndex)}(view, offset);
+        const size = ${className}.__${field.name}$size(view, offset);
         totalSize += size;
         offset += size;
     }
@@ -194,31 +162,23 @@ function sizePartForDefinition(
 }
 
 // Create a getter function for the field
-function getterFunction(field: MessageDefinitionField, fieldIndex: number): string {
+function getterFunction(field: MessageDefinitionField): string {
   if (field.isConstant === true) {
     return "";
   }
 
-  if (field.name === "constructor") {
-    throw new Error("LazyMessageReader does not support a field named 'constructor'");
-  }
-
-  const isBuiltinReader = hasOwn(deserializers, field.type);
-  const isBuiltinSize = hasOwn(builtinSizes, field.type);
+  const isBuiltinReader = field.type in deserializers;
+  const isBuiltinSize = field.type in builtinSizes;
 
   // function to return a read array item
   const readerFn = isBuiltinReader
-    ? `deserializers[${sourceString(field.type)}]`
+    ? `deserializers.${field.type}`
     : `${sanitizeName(field.type)}.build`;
 
   // function to return size of individual array item
-  const sizeFn = isBuiltinSize
-    ? `builtinSizes[${sourceString(field.type)}]`
-    : `${sanitizeName(field.type)}.size`;
+  const sizeFn = isBuiltinSize ? `builtinSizes.${field.type}` : `${sanitizeName(field.type)}.size`;
 
   const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
-  const fieldName = sourceString(field.name);
-  const offsetFunctionName = fieldOffsetFunctionName(fieldIndex);
 
   if (field.isArray === true) {
     const arrLen = field.arrayLength;
@@ -226,38 +186,42 @@ function getterFunction(field: MessageDefinitionField, fieldIndex: number): stri
       // total size is known, which means we should use a builtin array reader
       if (fieldSize != undefined) {
         return `
-          get ${fieldName}() {
-            const offset = this.${offsetFunctionName}(this.#view, this.#offset);
-            return deserializers[${sourceString(`${field.type}Array`)}](this.#view, offset, ${arrayLengthSource(field)});
+          // ${field.type}[${arrLen}] ${field.name}
+          get ${field.name}() {
+            const offset = this.__${field.name}$offset(this.#view, this.#offset);
+            return deserializers.${field.type}Array(this.#view, offset, ${arrLen});
           }`;
       } else {
         // fixed size array of complex size items
         return `
-          get ${fieldName}() {
-            const offset = this.${offsetFunctionName}(this.#view, this.#offset);
-            return deserializers.fixedArray(this.#view, offset, ${arrayLengthSource(field)}, ${readerFn}, ${sizeFn});
+        // ${field.type}[${arrLen}] ${field.name}
+          get ${field.name}() {
+            const offset = this.__${field.name}$offset(this.#view, this.#offset);
+            return deserializers.fixedArray(this.#view, offset, ${arrLen}, ${readerFn}, ${sizeFn});
           }`;
       }
     } else {
       // total size is known, which means we should use a builtin array reader
       if (fieldSize != undefined) {
         return `
-          get ${fieldName}() {
-            const offset = this.${offsetFunctionName}(this.#view, this.#offset);
+          // ${field.type}[] ${field.name}
+          get ${field.name}() {
+            const offset = this.__${field.name}$offset(this.#view, this.#offset);
             const len = this.#view.getUint32(offset, true);
-            return deserializers[${sourceString(`${field.type}Array`)}](this.#view, offset + 4, len);
+            return deserializers.${field.type}Array(this.#view, offset + 4, len);
           }`;
       } else {
         return `
-          get ${fieldName}() {
-            const offset = this.${offsetFunctionName}(this.#view, this.#offset);
+          // ${field.type}[] ${field.name}
+          get ${field.name}() {
+            const offset = this.__${field.name}$offset(this.#view, this.#offset);
             return deserializers.dynamicArray(this.#view, offset, ${readerFn}, ${sizeFn});
           }`;
       }
     }
   } else {
-    return `get ${fieldName}() {
-        const offset = this.${offsetFunctionName}(this.#view, this.#offset);
+    return `get ${field.name}() {
+        const offset = this.__${field.name}$offset(this.#view, this.#offset);
         return ${readerFn}(this.#view, offset);
       }`;
   }
@@ -275,6 +239,8 @@ function getterFunction(field: MessageDefinitionField, fieldIndex: number): stri
 export default function buildReader(
   definitions: readonly MessageDefinition[],
 ): SerializedMessageReader {
+  validateMessageDefinitionsForCodegen(definitions, { validateTypeNames: true });
+
   const classes = new Array<string>();
   const rootClassName = "__RootMsg";
 
@@ -285,9 +251,9 @@ export default function buildReader(
     const initializers = new Array<string>();
 
     // getters need to "look back" at the previous field to create the offset function calls
-    let prevField: { index: number } | undefined;
+    let prevField: MessageDefinitionField | undefined;
 
-    for (const [fieldIndex, field] of type.definitions.entries()) {
+    for (const field of type.definitions) {
       // constants have no impact on deserialization
       if (field.isConstant === true) {
         continue;
@@ -298,27 +264,26 @@ export default function buildReader(
       // the first first field is at offset 0
       if (prevField == undefined) {
         offsetFns.push(`
-          ${fieldOffsetFunctionName(fieldIndex)}(view, initOffset) {
+          __${field.name}$offset(view, initOffset) {
             return initOffset;
           }`);
       } else {
         // offsets tell you where the raw data of your field starts (including any length bytes)
         // they are the size of the offset of the previous field + size of previous field
-        const cacheName = fieldOffsetCacheName(fieldIndex);
+        initializers.push(`#_${field.name}_offset_cache = undefined;`);
         offsetFns.push(`
-          ${fieldOffsetFunctionName(fieldIndex)}(view, initOffset) {
-            if (this.${cacheName}) {
-              return this.${cacheName};
+          __${field.name}$offset(view, initOffset) {
+            if (this.#_${field.name}_offset_cache) {
+              return this.#_${field.name}_offset_cache;
             }
-            const prevOffset = this.${fieldOffsetFunctionName(prevField.index)}(view, initOffset);
-            const totalOffset = prevOffset + ${name}.${fieldSizeFunctionName(prevField.index)}(view, prevOffset);
-            this.${cacheName} = totalOffset;
+            const prevOffset = this.__${prevField.name}$offset(view, initOffset);
+            const totalOffset = prevOffset + ${name}.__${prevField.name}$size(view, prevOffset);
+            this.#_${field.name}_offset_cache = totalOffset;
             return totalOffset;
           }`);
-        initializers.push(`${cacheName} = undefined;`);
       }
 
-      prevField = { index: fieldIndex };
+      prevField = field;
     }
 
     const messageSrc = `class ${name} {

--- a/packages/rosmsg-serialization/src/buildReader.ts
+++ b/packages/rosmsg-serialization/src/buildReader.ts
@@ -63,6 +63,37 @@ function sanitizeName(name: string): string {
   return name.replace(/^[0-9]|[^a-zA-Z0-9_]/g, "_");
 }
 
+function sourceString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function hasOwn(object: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function arrayLengthSource(field: MessageDefinitionField): string {
+  const { arrayLength } = field;
+  if (arrayLength == undefined) {
+    return "undefined";
+  }
+  if (!Number.isSafeInteger(arrayLength) || arrayLength < 0) {
+    throw new Error(`Invalid array length ${String(arrayLength)} for field '${field.name}'`);
+  }
+  return String(arrayLength);
+}
+
+function fieldSizeFunctionName(fieldIndex: number): string {
+  return `__field${fieldIndex}$size`;
+}
+
+function fieldOffsetFunctionName(fieldIndex: number): string {
+  return `__field${fieldIndex}$offset`;
+}
+
+function fieldOffsetCacheName(fieldIndex: number): string {
+  return `#_field${fieldIndex}_offset_cache`;
+}
+
 interface SerializedMessageReader {
   build: (view: DataView, offset?: number) => unknown;
   size: (view: DataView, offset?: number) => number;
@@ -70,12 +101,13 @@ interface SerializedMessageReader {
 }
 
 // Return a static size function for our @param field
-function sizeFunction(field: MessageDefinitionField): string {
+function sizeFunction(field: MessageDefinitionField, fieldIndex: number): string {
   if (field.isConstant === true) {
     return "";
   }
 
   const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
+  const sizeFunctionName = fieldSizeFunctionName(fieldIndex);
 
   // if the field size is not known, size will be calculated on-demand
   if (fieldSize == undefined) {
@@ -86,31 +118,31 @@ function sizeFunction(field: MessageDefinitionField): string {
     if (field.isArray === true) {
       if (field.arrayLength != undefined) {
         return `
-          static __${field.name}$size(view /* dataview */, offset) {
-              return builtinSizes.fixedArray(view, offset, ${field.arrayLength}, ${fieldSizeFn});
+          static ${sizeFunctionName}(view /* dataview */, offset) {
+              return builtinSizes.fixedArray(view, offset, ${arrayLengthSource(field)}, ${fieldSizeFn});
           }`;
       } else {
         return `
-          static __${field.name}$size(view /* dataview */, offset) {
+          static ${sizeFunctionName}(view /* dataview */, offset) {
               return builtinSizes.array(view, offset, ${fieldSizeFn});
           }`;
       }
     }
 
     return `
-      static __${field.name}$size(view /* dataview */, offset) {
+      static ${sizeFunctionName}(view /* dataview */, offset) {
           return ${fieldSizeFn}(view, offset);
       }`;
   } else {
     if (field.isArray === true) {
       if (field.arrayLength != undefined) {
         return `
-          static __${field.name}$size(view /* dataview */, offset) {
-            return ${fieldSize} * ${field.arrayLength};
+          static ${sizeFunctionName}(view /* dataview */, offset) {
+            return ${fieldSize} * ${arrayLengthSource(field)};
           }`;
       } else {
         return `
-          static __${field.name}$size(view /* dataview */, offset) {
+          static ${sizeFunctionName}(view /* dataview */, offset) {
             const len = view.getUint32(offset, true);
             return 4 + len * ${fieldSize};
           }`;
@@ -118,14 +150,18 @@ function sizeFunction(field: MessageDefinitionField): string {
     }
 
     return `
-      static __${field.name}$size(view /* dataview */, offset) {
+      static ${sizeFunctionName}(view /* dataview */, offset) {
           return ${fieldSize};
       }`;
   }
 }
 
 // Return the part of the static size() function for our message class for @param field
-function sizePartForDefinition(className: string, field: MessageDefinitionField): string {
+function sizePartForDefinition(
+  className: string,
+  field: MessageDefinitionField,
+  fieldIndex: number,
+): string {
   if (field.isConstant === true) {
     return "";
   }
@@ -135,15 +171,13 @@ function sizePartForDefinition(className: string, field: MessageDefinitionField)
 
   if (fieldSize != undefined && (isFixedArray || field.isArray === false)) {
     if (field.arrayLength != undefined) {
-      const totalSize = fieldSize * field.arrayLength;
+      const totalSize = fieldSize * Number(arrayLengthSource(field));
       return `
-        // ${field.type}[${field.arrayLength}] ${field.name}
         totalSize += ${totalSize};
         offset += ${totalSize};
       `;
     } else {
       return `
-        // ${field.type} ${field.name}
         totalSize += ${fieldSize};
         offset += ${fieldSize};
       `;
@@ -151,9 +185,8 @@ function sizePartForDefinition(className: string, field: MessageDefinitionField)
   }
 
   return `
-    // ${field.type} ${field.name}
     {
-        const size = ${className}.__${field.name}$size(view, offset);
+        const size = ${className}.${fieldSizeFunctionName(fieldIndex)}(view, offset);
         totalSize += size;
         offset += size;
     }
@@ -161,23 +194,31 @@ function sizePartForDefinition(className: string, field: MessageDefinitionField)
 }
 
 // Create a getter function for the field
-function getterFunction(field: MessageDefinitionField): string {
+function getterFunction(field: MessageDefinitionField, fieldIndex: number): string {
   if (field.isConstant === true) {
     return "";
   }
 
-  const isBuiltinReader = field.type in deserializers;
-  const isBuiltinSize = field.type in builtinSizes;
+  if (field.name === "constructor") {
+    throw new Error("LazyMessageReader does not support a field named 'constructor'");
+  }
+
+  const isBuiltinReader = hasOwn(deserializers, field.type);
+  const isBuiltinSize = hasOwn(builtinSizes, field.type);
 
   // function to return a read array item
   const readerFn = isBuiltinReader
-    ? `deserializers.${field.type}`
+    ? `deserializers[${sourceString(field.type)}]`
     : `${sanitizeName(field.type)}.build`;
 
   // function to return size of individual array item
-  const sizeFn = isBuiltinSize ? `builtinSizes.${field.type}` : `${sanitizeName(field.type)}.size`;
+  const sizeFn = isBuiltinSize
+    ? `builtinSizes[${sourceString(field.type)}]`
+    : `${sanitizeName(field.type)}.size`;
 
   const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
+  const fieldName = sourceString(field.name);
+  const offsetFunctionName = fieldOffsetFunctionName(fieldIndex);
 
   if (field.isArray === true) {
     const arrLen = field.arrayLength;
@@ -185,42 +226,38 @@ function getterFunction(field: MessageDefinitionField): string {
       // total size is known, which means we should use a builtin array reader
       if (fieldSize != undefined) {
         return `
-          // ${field.type}[${arrLen}] ${field.name}
-          get ${field.name}() {
-            const offset = this.__${field.name}$offset(this.#view, this.#offset);
-            return deserializers.${field.type}Array(this.#view, offset, ${arrLen});
+          get ${fieldName}() {
+            const offset = this.${offsetFunctionName}(this.#view, this.#offset);
+            return deserializers[${sourceString(`${field.type}Array`)}](this.#view, offset, ${arrayLengthSource(field)});
           }`;
       } else {
         // fixed size array of complex size items
         return `
-        // ${field.type}[${arrLen}] ${field.name}
-          get ${field.name}() {
-            const offset = this.__${field.name}$offset(this.#view, this.#offset);
-            return deserializers.fixedArray(this.#view, offset, ${arrLen}, ${readerFn}, ${sizeFn});
+          get ${fieldName}() {
+            const offset = this.${offsetFunctionName}(this.#view, this.#offset);
+            return deserializers.fixedArray(this.#view, offset, ${arrayLengthSource(field)}, ${readerFn}, ${sizeFn});
           }`;
       }
     } else {
       // total size is known, which means we should use a builtin array reader
       if (fieldSize != undefined) {
         return `
-          // ${field.type}[] ${field.name}
-          get ${field.name}() {
-            const offset = this.__${field.name}$offset(this.#view, this.#offset);
+          get ${fieldName}() {
+            const offset = this.${offsetFunctionName}(this.#view, this.#offset);
             const len = this.#view.getUint32(offset, true);
-            return deserializers.${field.type}Array(this.#view, offset + 4, len);
+            return deserializers[${sourceString(`${field.type}Array`)}](this.#view, offset + 4, len);
           }`;
       } else {
         return `
-          // ${field.type}[] ${field.name}
-          get ${field.name}() {
-            const offset = this.__${field.name}$offset(this.#view, this.#offset);
+          get ${fieldName}() {
+            const offset = this.${offsetFunctionName}(this.#view, this.#offset);
             return deserializers.dynamicArray(this.#view, offset, ${readerFn}, ${sizeFn});
           }`;
       }
     }
   } else {
-    return `get ${field.name}() {
-        const offset = this.__${field.name}$offset(this.#view, this.#offset);
+    return `get ${fieldName}() {
+        const offset = this.${offsetFunctionName}(this.#view, this.#offset);
         return ${readerFn}(this.#view, offset);
       }`;
   }
@@ -248,9 +285,9 @@ export default function buildReader(
     const initializers = new Array<string>();
 
     // getters need to "look back" at the previous field to create the offset function calls
-    let prevField: MessageDefinitionField | undefined;
+    let prevField: { index: number } | undefined;
 
-    for (const field of type.definitions) {
+    for (const [fieldIndex, field] of type.definitions.entries()) {
       // constants have no impact on deserialization
       if (field.isConstant === true) {
         continue;
@@ -261,26 +298,27 @@ export default function buildReader(
       // the first first field is at offset 0
       if (prevField == undefined) {
         offsetFns.push(`
-          __${field.name}$offset(view, initOffset) {
+          ${fieldOffsetFunctionName(fieldIndex)}(view, initOffset) {
             return initOffset;
           }`);
       } else {
         // offsets tell you where the raw data of your field starts (including any length bytes)
         // they are the size of the offset of the previous field + size of previous field
-        initializers.push(`#_${field.name}_offset_cache = undefined;`);
+        const cacheName = fieldOffsetCacheName(fieldIndex);
         offsetFns.push(`
-          __${field.name}$offset(view, initOffset) {
-            if (this.#_${field.name}_offset_cache) {
-              return this.#_${field.name}_offset_cache;
+          ${fieldOffsetFunctionName(fieldIndex)}(view, initOffset) {
+            if (this.${cacheName}) {
+              return this.${cacheName};
             }
-            const prevOffset = this.__${prevField.name}$offset(view, initOffset);
-            const totalOffset = prevOffset + ${name}.__${prevField.name}$size(view, prevOffset);
-            this.#_${field.name}_offset_cache = totalOffset;
+            const prevOffset = this.${fieldOffsetFunctionName(prevField.index)}(view, initOffset);
+            const totalOffset = prevOffset + ${name}.${fieldSizeFunctionName(prevField.index)}(view, prevOffset);
+            this.${cacheName} = totalOffset;
             return totalOffset;
           }`);
+        initializers.push(`${cacheName} = undefined;`);
       }
 
-      prevField = field;
+      prevField = { index: fieldIndex };
     }
 
     const messageSrc = `class ${name} {

--- a/packages/rosmsg-serialization/src/validateMessageDefinitions.ts
+++ b/packages/rosmsg-serialization/src/validateMessageDefinitions.ts
@@ -1,0 +1,103 @@
+import type { MessageDefinition } from "@foxglove/message-definition";
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
+const ROS_TYPE_PATTERN = /^[A-Za-z][A-Za-z0-9_]*(\/[A-Za-z][A-Za-z0-9_]*)?$/;
+
+const RESERVED_WORDS = new Set([
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "null",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
+const UNSAFE_PROPERTY_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+
+function friendlyName(name: string): string {
+  return name.replace(/\//g, "_");
+}
+
+function assertSafeIdentifier(name: string, label: string): void {
+  if (
+    !IDENTIFIER_PATTERN.test(name) ||
+    RESERVED_WORDS.has(name) ||
+    UNSAFE_PROPERTY_NAMES.has(name)
+  ) {
+    throw new Error(`Invalid message definition ${label}: '${name}' is not a safe identifier`);
+  }
+}
+
+function assertSafeRosTypeName(name: string, label: string): void {
+  if (!ROS_TYPE_PATTERN.test(name)) {
+    throw new Error(`Invalid message definition ${label}: '${name}' is not a safe ROS type name`);
+  }
+}
+
+export function validateMessageDefinitionsForCodegen(
+  definitions: readonly MessageDefinition[],
+  options: { validateTypeNames?: boolean } = {},
+): void {
+  const validateTypeNames = options.validateTypeNames ?? false;
+  for (const type of definitions) {
+    if (validateTypeNames && type.name != undefined) {
+      assertSafeRosTypeName(type.name, "type name");
+      assertSafeIdentifier(friendlyName(type.name), "generated type name");
+    }
+
+    for (const field of type.definitions) {
+      if (field.isConstant === true) {
+        continue;
+      }
+
+      assertSafeIdentifier(field.name, "field name");
+      assertSafeRosTypeName(field.type, "field type");
+      if (field.isComplex !== true) {
+        assertSafeIdentifier(field.type, "primitive field type");
+      }
+
+      if (
+        field.arrayLength != undefined &&
+        (!Number.isSafeInteger(field.arrayLength) || field.arrayLength < 0)
+      ) {
+        throw new Error(
+          `Invalid message definition array length for field '${field.name}': ${String(
+            field.arrayLength,
+          )}`,
+        );
+      }
+    }
+  }
+}

--- a/packages/rosmsg-serialization/src/validateMessageDefinitions.ts
+++ b/packages/rosmsg-serialization/src/validateMessageDefinitions.ts
@@ -3,47 +3,6 @@ import type { MessageDefinition } from "@foxglove/message-definition";
 const IDENTIFIER_PATTERN = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
 const ROS_TYPE_PATTERN = /^[A-Za-z][A-Za-z0-9_]*(\/[A-Za-z][A-Za-z0-9_]*)?$/;
 
-const RESERVED_WORDS = new Set([
-  "await",
-  "break",
-  "case",
-  "catch",
-  "class",
-  "const",
-  "continue",
-  "debugger",
-  "default",
-  "delete",
-  "do",
-  "else",
-  "enum",
-  "export",
-  "extends",
-  "false",
-  "finally",
-  "for",
-  "function",
-  "if",
-  "import",
-  "in",
-  "instanceof",
-  "new",
-  "null",
-  "return",
-  "super",
-  "switch",
-  "this",
-  "throw",
-  "true",
-  "try",
-  "typeof",
-  "var",
-  "void",
-  "while",
-  "with",
-  "yield",
-]);
-
 const UNSAFE_PROPERTY_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 
 function friendlyName(name: string): string {
@@ -51,11 +10,7 @@ function friendlyName(name: string): string {
 }
 
 function assertSafeIdentifier(name: string, label: string): void {
-  if (
-    !IDENTIFIER_PATTERN.test(name) ||
-    RESERVED_WORDS.has(name) ||
-    UNSAFE_PROPERTY_NAMES.has(name)
-  ) {
+  if (!IDENTIFIER_PATTERN.test(name) || UNSAFE_PROPERTY_NAMES.has(name)) {
     throw new Error(`Invalid message definition ${label}: '${name}' is not a safe identifier`);
   }
 }

--- a/packages/rosmsg-serialization/src/validateMessageDefinitions.ts
+++ b/packages/rosmsg-serialization/src/validateMessageDefinitions.ts
@@ -1,58 +1,25 @@
 import type { MessageDefinition } from "@foxglove/message-definition";
 
-const IDENTIFIER_PATTERN = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
-const ROS_TYPE_PATTERN = /^[A-Za-z][A-Za-z0-9_]*(\/[A-Za-z][A-Za-z0-9_]*)?$/;
+const ROS_FIELD_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
 
-const UNSAFE_PROPERTY_NAMES = new Set(["__proto__", "constructor", "prototype"]);
-
-function friendlyName(name: string): string {
-  return name.replace(/\//g, "_");
-}
-
-function assertSafeIdentifier(name: string, label: string): void {
-  if (!IDENTIFIER_PATTERN.test(name) || UNSAFE_PROPERTY_NAMES.has(name)) {
-    throw new Error(`Invalid message definition ${label}: '${name}' is not a safe identifier`);
-  }
-}
-
-function assertSafeRosTypeName(name: string, label: string): void {
-  if (!ROS_TYPE_PATTERN.test(name)) {
-    throw new Error(`Invalid message definition ${label}: '${name}' is not a safe ROS type name`);
+function assertValidRosFieldName(name: string): void {
+  if (!ROS_FIELD_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid message definition field name: '${name}' is not a valid ROS field name`,
+    );
   }
 }
 
 export function validateMessageDefinitionsForCodegen(
   definitions: readonly MessageDefinition[],
-  options: { validateTypeNames?: boolean } = {},
 ): void {
-  const validateTypeNames = options.validateTypeNames ?? false;
   for (const type of definitions) {
-    if (validateTypeNames && type.name != undefined) {
-      assertSafeRosTypeName(type.name, "type name");
-      assertSafeIdentifier(friendlyName(type.name), "generated type name");
-    }
-
     for (const field of type.definitions) {
       if (field.isConstant === true) {
         continue;
       }
 
-      assertSafeIdentifier(field.name, "field name");
-      assertSafeRosTypeName(field.type, "field type");
-      if (field.isComplex !== true) {
-        assertSafeIdentifier(field.type, "primitive field type");
-      }
-
-      if (
-        field.arrayLength != undefined &&
-        (!Number.isSafeInteger(field.arrayLength) || field.arrayLength < 0)
-      ) {
-        throw new Error(
-          `Invalid message definition array length for field '${field.name}': ${String(
-            field.arrayLength,
-          )}`,
-        );
-      }
+      assertValidRosFieldName(field.name);
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog
Reject invalid ROS 1 field names when constructing message readers and writers, preventing crafted `MessageDefinition` schemas from executing arbitrary JavaScript during code generation.

### Docs
None

### Description
Harden `@foxglove/rosmsg-serialization` by validating schema-provided field names before they reach generated JavaScript. Non-constant field names must match the ROS1 field-name grammar (`[A-Za-z][A-Za-z0-9_]*`); invalid names are rejected before `new Function`/`eval` compilation.

This keeps the fix narrow, preserves the existing generated source shape for valid schemas, and covers eager readers, lazy readers, and the writer generator with regressions for malicious field names that previously could inject JavaScript.

### Testing
- [ ] Attempt to construct a reader or writer with an invalid ROS field name and verify construction fails without executing schema text.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0feb917d-4549-4dda-a4c3-8352f397de80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0feb917d-4549-4dda-a4c3-8352f397de80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

