### PR TITLE
Cover more string sanitization edge cases

### DIFF
--- a/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/LazyMessageReader.test.ts
@@ -1,3 +1,4 @@
+import { MessageDefinition } from "@foxglove/message-definition";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import * as prettier from "prettier";
 
@@ -139,5 +140,29 @@ describe("LazyReader", () => {
     const read = reader.readMessage(buffer);
     expect(read.custom.first).toEqual(3);
     expect(read.custom.first_offset).toEqual(7);
+  });
+
+  it("sanitizes untrusted field names before generating reader source", () => {
+    const unsafeFieldName = "bad-name";
+    const definitions: MessageDefinition[] = [
+      {
+        definitions: [
+          { isArray: false, isComplex: false, name: unsafeFieldName, type: "uint8" },
+          { isArray: false, isComplex: false, name: "__proto__", type: "uint8" },
+          { isArray: false, isComplex: false, name: "constructor", type: "uint8" },
+        ],
+        name: undefined,
+      },
+    ];
+
+    const buffer = Uint8Array.from([0x02, 0x03, 0x04]);
+    const reader = new LazyMessageReader<Record<string, unknown>>(definitions);
+    const read = reader.readMessage(buffer);
+
+    expect(reader.source()).not.toContain(unsafeFieldName);
+    expect(read["bad_name"]).toEqual(2);
+    expect(read["___proto__"]).toEqual(3);
+    expect(read["_constructor"]).toEqual(4);
+    expect(read.toObject()).toEqual({ bad_name: 2, ___proto__: 3, _constructor: 4 });
   });
 });

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -76,16 +76,22 @@ describe("MessageReader", () => {
           { isArray: false, isComplex: false, name: "bad-name", type: "uint8" },
           { isArray: false, isComplex: false, name: "__proto__", type: "uint8" },
           { isArray: false, isComplex: false, name: "constructor", type: "uint8" },
+          { isArray: false, isComplex: true, name: "custom-name", type: "bad-type/Custom" },
         ],
         name: undefined,
+      },
+      {
+        definitions: [{ isArray: false, isComplex: false, name: "value", type: "uint8" }],
+        name: "bad-type/Custom",
       },
     ];
     const reader = new MessageReader(definitions);
 
-    expect(reader.readMessage(Uint8Array.from([0x02, 0x03, 0x04]))).toEqual({
+    expect(reader.readMessage(Uint8Array.from([0x02, 0x03, 0x04, 0x05]))).toEqual({
       bad_name: 2,
       ___proto__: 3,
       _constructor: 4,
+      custom_name: { value: 5 },
     });
   });
 

--- a/packages/rosmsg-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.test.ts
@@ -7,6 +7,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { MessageDefinition } from "@foxglove/message-definition";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 
 import { MessageReader } from "./MessageReader";
@@ -66,6 +67,26 @@ describe("MessageReader", () => {
     expect(() => {
       output.firstName = "boooo";
     }).toThrow();
+  });
+
+  it("sanitizes untrusted field names before generating parser source", () => {
+    const definitions: MessageDefinition[] = [
+      {
+        definitions: [
+          { isArray: false, isComplex: false, name: "bad-name", type: "uint8" },
+          { isArray: false, isComplex: false, name: "__proto__", type: "uint8" },
+          { isArray: false, isComplex: false, name: "constructor", type: "uint8" },
+        ],
+        name: undefined,
+      },
+    ];
+    const reader = new MessageReader(definitions);
+
+    expect(reader.readMessage(Uint8Array.from([0x02, 0x03, 0x04]))).toEqual({
+      bad_name: 2,
+      ___proto__: 3,
+      _constructor: 4,
+    });
   });
 
   describe("lastReadHadTrailingBytes", () => {

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -10,7 +10,7 @@
 import { MessageDefinition } from "@foxglove/message-definition";
 
 import decodeString from "./decodeString";
-import { sanitizeMessageDefinitionFields } from "./sanitizeMessageDefinitionFields";
+import { sanitizeMessageDefinitionFields, sanitizeName } from "./sanitizeMessageDefinitionFields";
 
 type TypedArray =
   | Int8Array
@@ -190,7 +190,7 @@ const findTypeByName = (types: readonly MessageDefinition[], name = ""): NamedMe
   return { ...matches[0]!, name: foundName };
 };
 
-const friendlyName = (name: string) => name.replace(/\//g, "_");
+const friendlyName = (name: string) => sanitizeName(name);
 
 type NamedMessageDefinition = MessageDefinition & { name: string };
 
@@ -283,14 +283,14 @@ export const createParsers = ({
           readerLines.push(`  ${arrayName}[i] = new Record.${friendlyName(defType.name)}(reader);`);
         } else {
           // if the subtype is not complex its a simple low-level reader operation
-          readerLines.push(`  ${arrayName}[i] = reader.${def.type}();`);
+          readerLines.push(`  ${arrayName}[i] = reader.${sanitizeName(def.type)}();`);
         }
         readerLines.push("}"); // close the for-loop
       } else if (def.isComplex === true) {
         const defType = findTypeByName(sanitizedDefinitions, def.type);
         readerLines.push(`this.${def.name} = new Record.${friendlyName(defType.name)}(reader);`);
       } else {
-        readerLines.push(`this.${def.name} = reader.${def.type}();`);
+        readerLines.push(`this.${def.name} = reader.${sanitizeName(def.type)}();`);
       }
     });
     if (options.freeze === true) {
@@ -308,11 +308,12 @@ export const createParsers = ({
   `;
 
   for (const type of namedTypes) {
+    const typeReaderName = friendlyName(type.name);
     js += `
-  Record.${friendlyName(type.name)} = function(reader) {
+  Record.${typeReaderName} = function(reader) {
     ${constructorBody(type)}
   };
-  builtReaders.set(${JSON.stringify(type.name)}, Record.${friendlyName(type.name)});
+  builtReaders.set(${JSON.stringify(type.name)}, Record.${typeReaderName});
   `;
   }
 

--- a/packages/rosmsg-serialization/src/MessageReader.ts
+++ b/packages/rosmsg-serialization/src/MessageReader.ts
@@ -10,6 +10,7 @@
 import { MessageDefinition } from "@foxglove/message-definition";
 
 import decodeString from "./decodeString";
+import { sanitizeMessageDefinitionFields } from "./sanitizeMessageDefinitionFields";
 
 type TypedArray =
   | Int8Array
@@ -229,19 +230,21 @@ export const createParsers = ({
   options?: { freeze?: boolean };
   topLevelReaderKey: string;
 }): Map<string, new (reader: StandardTypeReader) => unknown> => {
-  if (definitions.length === 0) {
+  const sanitizedDefinitions = sanitizeMessageDefinitionFields(definitions);
+
+  if (sanitizedDefinitions.length === 0) {
     throw new Error(`no types given`);
   }
 
-  const unnamedTypes = definitions.filter((type) => !type.name);
+  const unnamedTypes = sanitizedDefinitions.filter((type) => !type.name);
   if (unnamedTypes.length > 1) {
     throw new Error("multiple unnamed types");
   }
 
-  const unnamedType = unnamedTypes.length > 0 ? unnamedTypes[0]! : definitions[0]!;
+  const unnamedType = unnamedTypes.length > 0 ? unnamedTypes[0]! : sanitizedDefinitions[0]!;
 
   // keep only definitions with a name
-  const namedTypes: NamedMessageDefinition[] = definitions.filter(
+  const namedTypes: NamedMessageDefinition[] = sanitizedDefinitions.filter(
     (type) => !!type.name,
   ) as NamedMessageDefinition[];
 
@@ -275,7 +278,7 @@ export const createParsers = ({
         readerLines.push(`for (var i = 0; i < ${lenField}; i++) {`);
         // if the sub type is complex we need to allocate it and parse its values
         if (def.isComplex === true) {
-          const defType = findTypeByName(definitions, def.type);
+          const defType = findTypeByName(sanitizedDefinitions, def.type);
           // recursively call the constructor for the sub-type
           readerLines.push(`  ${arrayName}[i] = new Record.${friendlyName(defType.name)}(reader);`);
         } else {
@@ -284,7 +287,7 @@ export const createParsers = ({
         }
         readerLines.push("}"); // close the for-loop
       } else if (def.isComplex === true) {
-        const defType = findTypeByName(definitions, def.type);
+        const defType = findTypeByName(sanitizedDefinitions, def.type);
         readerLines.push(`this.${def.name} = new Record.${friendlyName(defType.name)}(reader);`);
       } else {
         readerLines.push(`this.${def.name} = reader.${def.type}();`);

--- a/packages/rosmsg-serialization/src/MessageWriter.test.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.test.ts
@@ -7,6 +7,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { MessageDefinition } from "@foxglove/message-definition";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 
 import { MessageReader } from "./MessageReader";
@@ -438,6 +439,40 @@ describe("MessageWriter", () => {
       const writer = new MessageWriter(parseMessageDefinition(messageDefinition));
       expect(writer.calculateByteSize(message)).toEqual(108);
     });
+  });
+
+  it("sanitizes untrusted field and type names before generating writer source", () => {
+    const definitions: MessageDefinition[] = [
+      {
+        definitions: [
+          { isArray: false, isComplex: false, name: "bad-name", type: "uint8" },
+          {
+            arrayLength: undefined,
+            isArray: true,
+            isComplex: false,
+            name: "arr-name",
+            type: "uint8",
+          },
+          { isArray: false, isComplex: true, name: "custom-name", type: "bad-type/Custom" },
+        ],
+        name: undefined,
+      },
+      {
+        definitions: [{ isArray: false, isComplex: false, name: "value", type: "uint8" }],
+        name: "bad-type/Custom",
+      },
+    ];
+    const writer = new MessageWriter(definitions);
+    const message = {
+      arr_name: Uint8Array.from([3, 4]),
+      bad_name: 2,
+      custom_name: { value: 5 },
+    };
+
+    expect(writer.calculateByteSize(message)).toEqual(8);
+    expect(writer.writeMessage(message)).toEqual(
+      Uint8Array.from([0x02, 0x02, 0x00, 0x00, 0x00, 0x03, 0x04, 0x05]),
+    );
   });
 
   it.each([

--- a/packages/rosmsg-serialization/src/MessageWriter.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.ts
@@ -9,6 +9,7 @@
 
 import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
 
+import { sanitizeMessageDefinitionFields, sanitizeName } from "./sanitizeMessageDefinitionFields";
 import { stringLengthUtf8 } from "./stringLengthUtf8";
 
 export interface Time {
@@ -223,25 +224,28 @@ const findTypeByName = (types: MessageDefinition[], name = ""): NamedRosMsgDefin
   return { ...matches[0]!, name: foundName };
 };
 
-const friendlyName = (name: string): string => name.replace(/\//g, "_");
+const friendlyName = (name: string): string => sanitizeName(name);
+
 type WriterAndSizeCalculator = {
   writer: (message: unknown, output: Uint8Array) => Uint8Array;
   byteSizeCalculator: (message: unknown) => number;
 };
 
 function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSizeCalculator {
-  if (types.length === 0) {
+  const sanitizedTypes = sanitizeMessageDefinitionFields(types);
+
+  if (sanitizedTypes.length === 0) {
     throw new Error(`no types given`);
   }
 
-  const unnamedTypes = types.filter((type) => type.name == undefined);
+  const unnamedTypes = sanitizedTypes.filter((type) => type.name == undefined);
   if (unnamedTypes.length > 1) {
     throw new Error("multiple unnamed types");
   }
 
-  const unnamedType = unnamedTypes.length > 0 ? unnamedTypes[0]! : types[0]!;
+  const unnamedType = unnamedTypes.length > 0 ? unnamedTypes[0]! : sanitizedTypes[0]!;
 
-  const namedTypes: NamedRosMsgDefinition[] = types.filter(
+  const namedTypes: NamedRosMsgDefinition[] = sanitizedTypes.filter(
     (type) => type.name != undefined,
   ) as NamedRosMsgDefinition[];
 
@@ -256,9 +260,9 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
       }
 
       // Accesses the field we are currently writing. Pulled out for easy reuse.
-      const accessMessageField = `message["${def.name}"]`;
+      const accessMessageField = `message.${def.name}`;
       if (def.isArray ?? false) {
-        const lenField = `length_${def.name}`;
+        const lenField = sanitizeName(`length_${def.name}`);
         // set a variable pointing to the parsed fixed array length
         // or write the byte indicating the dynamic length
         if (def.arrayLength != undefined) {
@@ -272,20 +276,20 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
         lines.push(`for (var i = 0; i < ${lenField}; i++) {`);
         // if the sub type is complex we need to allocate it and parse its values
         if (def.isComplex ?? false) {
-          const defType = findTypeByName(types, def.type);
+          const defType = findTypeByName(sanitizedTypes, def.type);
           // recursively call the function for the sub-type
           lines.push(`  ${friendlyName(defType.name)}(${argName}, ${accessMessageField}[i]);`);
         } else {
           // if the subtype is not complex its a simple low-level operation
-          lines.push(`  ${argName}.${def.type}(${accessMessageField}[i]);`);
+          lines.push(`  ${argName}.${sanitizeName(def.type)}(${accessMessageField}[i]);`);
         }
         lines.push("}"); // close the for-loop
       } else if (def.isComplex ?? false) {
-        const defType = findTypeByName(types, def.type);
+        const defType = findTypeByName(sanitizedTypes, def.type);
         lines.push(`${friendlyName(defType.name)}(${argName}, ${accessMessageField});`);
       } else {
         // Call primitives directly.
-        lines.push(`${argName}.${def.type}(${accessMessageField});`);
+        lines.push(`${argName}.${sanitizeName(def.type)}(${accessMessageField});`);
       }
     });
     return lines.join("\n    ");
@@ -295,12 +299,13 @@ function createWriterAndSizeCalculator(types: MessageDefinition[]): WriterAndSiz
   let calculateSizeJs = "";
 
   namedTypes.forEach((t) => {
+    const typeWriterName = friendlyName(t.name);
     writerJs += `
-  function ${friendlyName(t.name)}(writer, message) {
+  function ${typeWriterName}(writer, message) {
     ${constructorBody(t, "writer")}
   };\n`;
     calculateSizeJs += `
-  function ${friendlyName(t.name)}(offsetCalculator, message) {
+  function ${typeWriterName}(offsetCalculator, message) {
     ${constructorBody(t, "offsetCalculator")}
   };\n`;
   });

--- a/packages/rosmsg-serialization/src/buildReader.ts
+++ b/packages/rosmsg-serialization/src/buildReader.ts
@@ -1,8 +1,10 @@
 import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
 
 import { createParsers, StandardTypeReader } from ".";
-import { deserializers, fixedSizeTypes, FixedSizeTypes } from "./BuiltinDeserialize";
+import { deserializers, fixedSizeTypes } from "./BuiltinDeserialize";
 import { sanitizeMessageDefinitionFields, sanitizeName } from "./sanitizeMessageDefinitionFields";
+
+const fixedSizeTypesByName: ReadonlyMap<string, number> = fixedSizeTypes;
 
 const builtinSizes = {
   // strings are the only builtin type that are variable size
@@ -72,7 +74,7 @@ function sizeFunction(field: MessageDefinitionField): string {
     return "";
   }
 
-  const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
+  const fieldSize = fixedSizeTypesByName.get(field.type);
 
   // if the field size is not known, size will be calculated on-demand
   if (fieldSize == undefined) {
@@ -127,7 +129,7 @@ function sizePartForDefinition(className: string, field: MessageDefinitionField)
     return "";
   }
 
-  const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
+  const fieldSize = fixedSizeTypesByName.get(field.type);
   const isFixedArray = field.isArray === true && field.arrayLength != undefined;
 
   if (fieldSize != undefined && (isFixedArray || field.isArray === false)) {
@@ -163,8 +165,9 @@ function getterFunction(field: MessageDefinitionField): string {
     return "";
   }
 
-  const isBuiltinReader = field.type in deserializers;
-  const isBuiltinSize = field.type in builtinSizes;
+  const fieldSize = fixedSizeTypesByName.get(field.type);
+  const isBuiltinReader = field.type === "string" || fieldSize != undefined;
+  const isBuiltinSize = field.type === "string";
 
   // function to return a read array item
   const readerFn = isBuiltinReader
@@ -173,8 +176,6 @@ function getterFunction(field: MessageDefinitionField): string {
 
   // function to return size of individual array item
   const sizeFn = isBuiltinSize ? `builtinSizes.${field.type}` : `${sanitizeName(field.type)}.size`;
-
-  const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
 
   if (field.isArray === true) {
     const arrLen = field.arrayLength;

--- a/packages/rosmsg-serialization/src/buildReader.ts
+++ b/packages/rosmsg-serialization/src/buildReader.ts
@@ -2,6 +2,7 @@ import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-def
 
 import { createParsers, StandardTypeReader } from ".";
 import { deserializers, fixedSizeTypes, FixedSizeTypes } from "./BuiltinDeserialize";
+import { sanitizeMessageDefinitionFields, sanitizeName } from "./sanitizeMessageDefinitionFields";
 
 const builtinSizes = {
   // strings are the only builtin type that are variable size
@@ -58,10 +59,6 @@ const builtinSizes = {
     return size;
   },
 };
-
-function sanitizeName(name: string): string {
-  return name.replace(/^[0-9]|[^a-zA-Z0-9_]/g, "_");
-}
 
 interface SerializedMessageReader {
   build: (view: DataView, offset?: number) => unknown;
@@ -238,10 +235,11 @@ function getterFunction(field: MessageDefinitionField): string {
 export default function buildReader(
   definitions: readonly MessageDefinition[],
 ): SerializedMessageReader {
+  const sanitizedDefinitions = sanitizeMessageDefinitionFields(definitions);
   const classes = new Array<string>();
   const rootClassName = "__RootMsg";
 
-  for (const type of definitions) {
+  for (const type of sanitizedDefinitions) {
     const name = sanitizeName(type.name ?? rootClassName);
 
     const offsetFns = new Array<string>();
@@ -343,7 +341,10 @@ export default function buildReader(
   // Since the root message depends on custom types we want those to be defined
   const src = classes.reverse().join("\n\n");
 
-  const typeReaders = createParsers({ definitions, topLevelReaderKey: rootClassName });
+  const typeReaders = createParsers({
+    definitions: sanitizedDefinitions,
+    topLevelReaderKey: rootClassName,
+  });
 
   // close over our builtin deserializers and builtin size functions
   // eslint-disable-next-line @typescript-eslint/no-implied-eval,no-new-func

--- a/packages/rosmsg-serialization/src/sanitizeMessageDefinitionFields.ts
+++ b/packages/rosmsg-serialization/src/sanitizeMessageDefinitionFields.ts
@@ -1,0 +1,30 @@
+import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
+
+const unsafePropertyNames = new Set(["__proto__", "constructor", "prototype"]);
+
+export function sanitizeName(name: string): string {
+  const sanitized = name.replace(/^[0-9]|[^a-zA-Z0-9_]/g, "_");
+  if (sanitized.length === 0) {
+    return "_";
+  }
+  return unsafePropertyNames.has(sanitized) ? `_${sanitized}` : sanitized;
+}
+
+function sanitizeField(field: MessageDefinitionField): MessageDefinitionField {
+  if (field.isConstant === true) {
+    return field;
+  }
+
+  const fieldName = field.name;
+  const sanitizedName = sanitizeName(fieldName);
+  return sanitizedName === fieldName ? field : { ...field, name: sanitizedName };
+}
+
+export function sanitizeMessageDefinitionFields(
+  definitions: readonly MessageDefinition[],
+): MessageDefinition[] {
+  return definitions.map((definition) => ({
+    ...definition,
+    definitions: definition.definitions.map(sanitizeField),
+  }));
+}

--- a/packages/rosmsg2-serialization/src/MessageReader.test.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.test.ts
@@ -1,3 +1,4 @@
+import { MessageDefinition } from "@foxglove/message-definition";
 import { parseRos2idl } from "@foxglove/ros2idl-parser";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 
@@ -226,6 +227,25 @@ describe("MessageReader", () => {
       expect(read).toEqual(expected);
     },
   );
+
+  it("reads untrusted field names as own data properties", () => {
+    const definitions: MessageDefinition[] = [
+      {
+        definitions: [
+          { isArray: false, isComplex: false, name: "__proto__", type: "uint8" },
+          { isArray: false, isComplex: false, name: "constructor", type: "uint8" },
+        ],
+        name: undefined,
+      },
+    ];
+    const reader = new MessageReader(definitions);
+    const read = reader.readMessage<Record<string, unknown>>(Uint8Array.from([0, 1, 0, 0, 2, 3]));
+
+    expect(Object.getPrototypeOf(read)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(read, "__proto__")).toBe(false);
+    expect(read["___proto__"]).toEqual(2);
+    expect(read["_constructor"]).toEqual(3);
+  });
 
   it.each([
     [

--- a/packages/rosmsg2-serialization/src/MessageReader.ts
+++ b/packages/rosmsg2-serialization/src/MessageReader.ts
@@ -3,6 +3,7 @@ import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-def
 import { Time as Ros1Time } from "@foxglove/rostime";
 
 import { messageDefinitionHasDataFields } from "./messageDefinitionHasDataFields";
+import { sanitizeName } from "./sanitizeName";
 
 type Ros2Time = {
   sec: number;
@@ -126,9 +127,9 @@ export class MessageReader<T = unknown> {
           for (let i = 0; i < arrayLength; i++) {
             array.push(this.#readComplexType(nestedDefinition, reader));
           }
-          msg[field.name] = array;
+          msg[sanitizeName(field.name)] = array;
         } else {
-          msg[field.name] = this.#readComplexType(nestedDefinition, reader);
+          msg[sanitizeName(field.name)] = this.#readComplexType(nestedDefinition, reader);
         }
       } else {
         // Primitive type
@@ -141,13 +142,13 @@ export class MessageReader<T = unknown> {
           }
           // For dynamic length arrays we need to read a uint32 prefix
           const arrayLength = field.arrayLength ?? reader.sequenceLength();
-          msg[field.name] = deser(reader, arrayLength);
+          msg[sanitizeName(field.name)] = deser(reader, arrayLength);
         } else {
           const deser = (this.#useRos1Time ? ros1TimeDeserializers : deserializers).get(field.type);
           if (deser == undefined) {
             throw new Error(`Unrecognized primitive type ${field.type}`);
           }
-          msg[field.name] = deser(reader);
+          msg[sanitizeName(field.name)] = deser(reader);
         }
       }
     }

--- a/packages/rosmsg2-serialization/src/sanitizeName.ts
+++ b/packages/rosmsg2-serialization/src/sanitizeName.ts
@@ -1,0 +1,9 @@
+const unsafePropertyNames = new Set(["__proto__", "constructor", "prototype"]);
+
+export function sanitizeName(name: string): string {
+  const sanitized = name.replace(/^[0-9]|[^a-zA-Z0-9_]/g, "_");
+  if (sanitized.length === 0) {
+    return "_";
+  }
+  return unsafePropertyNames.has(sanitized) ? `_${sanitized}` : sanitized;
+}


### PR DESCRIPTION
### Changelog

Hardened ROS message serialization against unsafe field and type names in programmatically supplied message definitions.

### Docs

None

### Description

This PR prevents untrusted `MessageDefinition` field and type names from being injected directly into generated JavaScript in the ROS 1 serialization package. Direct callers can construct `MessageDefinition[]` values without going through the `.msg` parser, so generated reader and writer code now sanitizes names before using them as identifiers, generated property names, offset helpers, and nested type function names.

The change also tightens related generated-code paths by routing `friendlyName` through the shared sanitizer, using sanitized primitive method names, and avoiding prototype-sensitive names such as `__proto__`, `constructor`, and `prototype`.

For ROS 2 deserialization, decoded field names are sanitized before assignment to the output object so unsafe names cannot mutate object prototypes or shadow special object properties.

Regression tests cover unsafe field names, unsafe type names, ROS 1 reader/writer code generation, and ROS 2 decoded output fields.

### Testing

No additional human verification required; this change hardens generated serialization/deserialization code paths and does not affect visual or interactive behavior.

### Links

None
