### PR TITLE
Bump @foxglove/rosmsg-serialization to 2.1.2

### DIFF
--- a/packages/rosmsg-serialization/package.json
+++ b/packages/rosmsg-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg-serialization",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "ROS 1 message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Changelog

Reject invalid ROS 1 field names to prevent code injection (#141)

### Docs

None

### Description

Updates the release metadata for `@foxglove/rosmsg-serialization` ahead of the next package publication. This patch release includes the fix from #141 that rejects invalid ROS 1 field names before code generation, preventing crafted `MessageDefinition` schemas from executing arbitrary JavaScript.

### Testing

- `yarn workspaces foreach -Rp --topological-dev --from @foxglove/rosmsg-serialization run build`
- `yarn workspace @foxglove/rosmsg-serialization test`

### Links

None
