### PR TITLE
Bump @foxglove/xmlrpc to v1.4.0

### DIFF
--- a/packages/xmlrpc/package.json
+++ b/packages/xmlrpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/xmlrpc",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "TypeScript library implementing an XMLRPC client and server with pluggable server backend",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Changelog
Bumped `@foxglove/xmlrpc` to 1.4.0.

### Docs
None

### Description
Resolve `js-yaml` vulnerabilities pulled in from `xmlbuilder2`: https://github.com/foxglove/ros-typescript/pull/98
